### PR TITLE
fix: preserve grim capture scale

### DIFF
--- a/src/screen_capture.cpp
+++ b/src/screen_capture.cpp
@@ -304,7 +304,7 @@ CaptureResult captureWithPortalScreenshot(const CaptureRequest &request)
 
 CaptureResult captureWithGrim(const CaptureRequest &request)
 {
-    const QStringList baseArguments{QStringLiteral("-t"), QStringLiteral("ppm"), QStringLiteral("-s"), QStringLiteral("1")};
+    const QStringList baseArguments{QStringLiteral("-t"), QStringLiteral("ppm")};
 
     if (request.sourceGeometry.isValid() && !request.sourceGeometry.isEmpty()) {
         QStringList arguments = baseArguments;


### PR DESCRIPTION
修复 Wayland HiDPI 屏幕下截图变模糊的问题，移除强制传给 `grim` 的 `-s 1` 参数。
- 如果这是刻意设置，我会关闭此PR
