### PR TITLE
fix: keep Wayland image clipboard alive

### DIFF
--- a/src/shot_window.cpp
+++ b/src/shot_window.cpp
@@ -6518,14 +6518,18 @@ void ShotWindow::copySelection()
         .value(QStringLiteral("XDG_SESSION_TYPE")).toLower() == QStringLiteral("wayland");
 
     if (isWayland) {
-        QProcess wlCopy;
-        wlCopy.setProgram(QStringLiteral("wl-copy"));
-        wlCopy.setArguments({QStringLiteral("--type"), QStringLiteral("image/png")});
-        wlCopy.start(QIODevice::WriteOnly);
-        if (wlCopy.waitForStarted(1000)) {
-            wlCopy.write(png);
-            wlCopy.closeWriteChannel();
-            wlCopy.waitForFinished(2500);
+        QTemporaryFile tempFile(QDir::tempPath() + QStringLiteral("/mark-shot-clipboard-XXXXXX.png"));
+        tempFile.setAutoRemove(false);
+        if (tempFile.open()) {
+            tempFile.write(png);
+            const QString tempPath = tempFile.fileName();
+            tempFile.close();
+
+            QProcess::startDetached(QStringLiteral("sh"),
+                                    {QStringLiteral("-c"),
+                                     QStringLiteral("wl-copy --foreground --type image/png < \"$1\"; rm -f \"$1\""),
+                                     QStringLiteral("mark-shot-clipboard"),
+                                     tempPath});
         }
     } else {
         QProcess xclip;


### PR DESCRIPTION
## Summary

Keep the Wayland image clipboard provider alive after copying a screenshot.

## Why

On Wayland, clipboard data is served by the process that owns the selection. The previous `wl-copy --type image/png` helper exited after receiving the PNG data, which can leave the active clipboard empty after clipboard managers such as cliphist observe the image.

This shows up with Noctalia/cliphist using an image watcher like:

```sh
wl-paste --type image --watch cliphist store
```

The screenshot is stored in clipboard history, but normal paste targets no longer see `image/png` in the active clipboard.

## What changed

The Wayland image copy path now writes the rendered PNG to a temporary file and starts a detached `wl-copy --foreground --type image/png` helper. That keeps the image selection available for paste targets while still allowing clipboard history tools to store it.

## Validation

- Built with `cmake --build /tmp/mark-shot/build`
- Verified with Noctalia/cliphist that copied screenshots appear in history
- Verified `wl-paste --list-types` continues to report `image/png` after copying a screenshot
