### PR TITLE
feat(save): make Ctrl+S quick-save

### DIFF
--- a/src/shot_window.cpp
+++ b/src/shot_window.cpp
@@ -19,11 +19,13 @@
 #include <QBoxLayout>
 #include <QComboBox>
 #include <QBrush>
-#include <QClipboard>
 #include <QContextMenuEvent>
 #include <QCoreApplication>
 #include <QCursor>
 #include <QDateTime>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusMessage>
 #include <QDir>
 #include <QDirIterator>
 #include <QEvent>
@@ -106,6 +108,28 @@ constexpr int kImageWindowMinimumToolbarPadding = 24;
 constexpr qsizetype kMaxSharpViewportPixels = 50'000'000;
 constexpr double kSharpKernelRadius = 2.5;
 constexpr int kMinSharpRowsPerThread = 64;
+
+bool sendDesktopNotification(const QString &summary, const QString &body, int timeoutMs = 2500)
+{
+    QDBusInterface notifications(QStringLiteral("org.freedesktop.Notifications"),
+                                 QStringLiteral("/org/freedesktop/Notifications"),
+                                 QStringLiteral("org.freedesktop.Notifications"),
+                                 QDBusConnection::sessionBus());
+    if (!notifications.isValid()) {
+        return false;
+    }
+
+    QDBusMessage reply = notifications.call(QStringLiteral("Notify"),
+                                            QStringLiteral("mark-shot"),
+                                            static_cast<uint>(0),
+                                            QString(),
+                                            summary,
+                                            body,
+                                            QStringList(),
+                                            QVariantMap(),
+                                            timeoutMs);
+    return reply.type() != QDBusMessage::ErrorMessage;
+}
 
 QColor propertyIconInkForFill(const QColor &fillColor)
 {
@@ -1894,7 +1918,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
             : action == Action::Pin                  ? QStringLiteral("Pin")
             : action == Action::OcrCopy              ? QStringLiteral("OCR")
             : action == Action::Copy                 ? QStringLiteral("Ctrl+C")
-            : action == Action::Save                 ? QStringLiteral("Ctrl+S")
+            : action == Action::Save                 ? QStringLiteral("Save As")
             : action == Action::ToggleToolbarLayout  ? QStringLiteral("Layout")
             : action == Action::ToggleCaptureScope   ? QStringLiteral("F")
                                                      : QStringLiteral("Esc");
@@ -1950,7 +1974,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
              addToolbarButton(Action::Pin, QStringLiteral("Pin"), m_actionToolbar),
              addToolbarButton(Action::OcrCopy, QStringLiteral("OCR"), m_actionToolbar),
              addToolbarButton(Action::Copy, QStringLiteral("Ctrl+C"), m_actionToolbar),
-             addToolbarButton(Action::Save, QStringLiteral("Ctrl+S"), m_actionToolbar),
+             addToolbarButton(Action::Save, QStringLiteral("Save As"), m_actionToolbar),
              addToolbarButton(Action::Cancel, QStringLiteral("Esc"), m_actionToolbar),
          }) {
         button->setIconSize(QSize(20, 20));
@@ -2503,7 +2527,7 @@ QPushButton *ShotWindow::addToolbarButton(Action action, const QString &shortcut
     } else if (action == Action::Copy) {
         connect(button, &QPushButton::clicked, this, [this] { copySelection(); });
     } else if (action == Action::Save) {
-        connect(button, &QPushButton::clicked, this, [this] { saveSelection(); });
+        connect(button, &QPushButton::clicked, this, [this] { saveSelectionAs(); });
     } else if (action == Action::Cancel) {
         connect(button, &QPushButton::clicked, this, [this] { close(); });
     }
@@ -7108,6 +7132,33 @@ void ShotWindow::saveSelection()
         return;
     }
 
+    const QString path = defaultSavePath();
+    if (output.save(path, "PNG")) {
+        const QString message = MS_TR("Saved to %1").arg(path);
+        // Keyboard save should finish without another dialog round-trip.
+        if (!sendDesktopNotification(QStringLiteral("Mark Shot"), message, 3000)) {
+            showToast(message, 2500);
+        }
+        QTimer::singleShot(150, this, [this] { close(); });
+        return;
+    }
+
+    showToast(MS_TR("Save failed"), 2500);
+}
+
+void ShotWindow::saveSelectionAs()
+{
+    commitTextEditor();
+
+    if (!hasUsableSelection()) {
+        return;
+    }
+
+    const QImage output = renderedSelection();
+    if (output.isNull()) {
+        return;
+    }
+
     if (m_openWithPanel) {
         m_openWithPanel->hide();
     }
@@ -7141,9 +7192,15 @@ void ShotWindow::saveSelection()
     connect(dialog, &QFileDialog::accepted, this, [this, dialog, output] {
         const QStringList files = dialog->selectedFiles();
         if (!files.isEmpty() && output.save(files.first(), "PNG")) {
-            close();
+            const QString message = MS_TR("Saved to %1").arg(files.first());
+            // Prefer desktop notifications because the window may close immediately after saving.
+            if (!sendDesktopNotification(QStringLiteral("Mark Shot"), message, 3000)) {
+                showToast(message, 2500);
+            }
+            QTimer::singleShot(150, this, [this] { close(); });
             return;
         }
+        showToast(MS_TR("Save failed"), 2500);
         show();
         raise();
         activateWindow();

--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -238,6 +238,7 @@ private:
     void showToast(const QString &text, int durationMs = 2000);
     QString saveSelectionToTempFile() const;
     void setCurrentColor(QColor color);
+    void saveSelectionAs();
     void saveSelection();
     void revealSelectionInfo();
     void setTool(Tool tool);

--- a/src/ui/i18n.cpp
+++ b/src/ui/i18n.cpp
@@ -61,6 +61,8 @@ const QHash<QString, QString> &chineseTable()
         {QStringLiteral("Save Pinned Image"), QStringLiteral("保存钉住的图片")},
         {QStringLiteral("Save Screenshot"), QStringLiteral("保存截图")},
         {QStringLiteral("PNG Images (*.png)"), QStringLiteral("PNG 图片 (*.png)")},
+        {QStringLiteral("Saved to %1"), QStringLiteral("已保存到 %1")},
+        {QStringLiteral("Save failed"), QStringLiteral("保存失败")},
 
         // Toolbar action names (also used as tooltips).
         {QStringLiteral("Move"), QStringLiteral("移动")},

--- a/src/ui/icons.cpp
+++ b/src/ui/icons.cpp
@@ -86,7 +86,7 @@ QString actionName(ShotWindow::Action action)
     case ShotWindow::Action::Copy:
         return QStringLiteral("Copy");
     case ShotWindow::Action::Save:
-        return QStringLiteral("Save");
+        return QStringLiteral("Save As");
     case ShotWindow::Action::Cancel:
         return QStringLiteral("Cancel");
     }


### PR DESCRIPTION
## Summary
- make `Ctrl+S` save directly to the default screenshot path
- keep the toolbar save action as explicit `Save As`
- prefer desktop notifications for save success, with toast fallback

## Background
The keyboard save shortcut should follow the fast path instead of opening an extra save dialog every time. The explicit toolbar action can continue to own the modal `Save As` flow.

Also, save success feedback can be easy to miss because the window closes immediately after saving. This change prefers desktop notifications so the result remains visible after the window disappears.

## Changes
- route `Ctrl+S` / `saveSelection()` to direct quick-save
- split dialog-based save flow into `saveSelectionAs()`
- update toolbar and action labels from `Save` to `Save As`
- add success and failure save messages

## Verification
- `Ctrl+S` saves directly without opening a dialog
- toolbar `Save As` still opens the file dialog
- successful saves show a desktop notification when available
- notification fallback remains a toast when D-Bus notifications are unavailable