### PR TITLE
Set layer-shell scope to 'dock' to suppress window animation

### DIFF
--- a/src/pinned_window_top.cpp
+++ b/src/pinned_window_top.cpp
@@ -134,7 +134,7 @@ markshot::layershell::FloatingOverlayConfig floatingOverlayConfig(QWidget *windo
     const int top = geometry.top() - screenGeometry.top();
 
     markshot::layershell::FloatingOverlayConfig config;
-    config.scope = QStringLiteral("mark-shot-pin");
+    config.scope = QStringLiteral("dock");
     config.keyboardInteractivity = markshot::layershell::KeyboardInteractivity::OnDemand;
     config.activateOnShow = true;
     config.closeOnDismissed = false;

--- a/src/scroll/scroll_session_window_lifecycle.cpp
+++ b/src/scroll/scroll_session_window_lifecycle.cpp
@@ -100,7 +100,7 @@ bool ScrollSessionWindow::configureLayerShell(QScreen *screen)
     // Do not hold exclusive keyboard focus; the page below should keep receiving
     // keyboard and wheel input while the panel can still take focus when clicked.
     markshot::layershell::FloatingOverlayConfig config;
-    config.scope = QStringLiteral("mark-shot-scroll");
+    config.scope = QStringLiteral("dock");
     config.keyboardInteractivity = markshot::layershell::KeyboardInteractivity::OnDemand;
     config.closeOnDismissed = false;
     config.wantsActiveScreenWhenNoScreen = true;

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -623,7 +623,7 @@ bool ShotWindow::configureLayerShell(QScreen *screen)
     return markshot::layershell::configureOverlay(
         this,
         screen,
-        {QStringLiteral("mark-shot"),
+        {QStringLiteral("dock"),
          markshot::layershell::KeyboardInteractivity::Exclusive,
          true,
          true});


### PR DESCRIPTION
[before.webm](https://github.com/user-attachments/assets/13635681-3e4a-4cc8-9075-99642cc46967)
[after.webm](https://github.com/user-attachments/assets/1850b1b4-dc82-44c8-8f22-ae44ca5d040e) ("fade in" is caused by video codec, not actual)
