### PR TITLE
fix(settings): override application palette to fix GNOME Adwaita theme

### DIFF
--- a/src/settings/settings_dialog.cpp
+++ b/src/settings/settings_dialog.cpp
@@ -19,6 +19,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include <QPalette>
 #include <QPointer>
 #include <QPushButton>
 #include <QScreen>
@@ -52,6 +53,23 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     setWindowIcon(markshot::ui::applicationIcon());
     setMinimumSize(820, 600);
     resize(900, 640);
+
+    QPalette pal;
+    pal.setColor(QPalette::Window, tokens::kWindowBackground);
+    pal.setColor(QPalette::WindowText, tokens::kTextPrimary);
+    pal.setColor(QPalette::Base, tokens::kInputBackground);
+    pal.setColor(QPalette::AlternateBase, tokens::kCardSurface);
+    pal.setColor(QPalette::Text, tokens::kTextPrimary);
+    pal.setColor(QPalette::Button, tokens::kCardSurface);
+    pal.setColor(QPalette::ButtonText, tokens::kTextPrimary);
+    pal.setColor(QPalette::ToolTipBase, tokens::kCardSurface);
+    pal.setColor(QPalette::ToolTipText, tokens::kTextPrimary);
+    pal.setColor(QPalette::BrightText, tokens::kAccent);
+    pal.setColor(QPalette::Link, tokens::kAccent);
+    pal.setColor(QPalette::Highlight, tokens::kAccent);
+    pal.setColor(QPalette::HighlightedText, tokens::kAccentInk);
+    qApp->setPalette(pal);
+
     setStyleSheet(tokens::settingsStyleSheet());
 
     auto *rootLayout = new QVBoxLayout(this);


### PR DESCRIPTION
GNOME 下 libqgtk3 平台主题插件会将基础 QPalette 设为浅色，
widget 级和类级 setPalette() 均无法完全覆盖（palette 合并机制）。
通过 qApp->setPalette() 设置应用级深色 palette 彻底替换。

|之前|之后|
|:--:|:--:|
|<img width="922" height="700" alt="之前" src="https://github.com/user-attachments/assets/9b8061ef-833d-470e-9427-930cf90c729d" />|<img width="922" height="700" alt="之后" src="https://github.com/user-attachments/assets/56a945ec-9dee-48ca-8488-a797723cc95b" />

