### PR TITLE
fix: auto-select window detection script for current desktop

### DIFF
--- a/src/window_detection.cpp
+++ b/src/window_detection.cpp
@@ -594,19 +594,20 @@ std::optional<bool> configuredWindowDetectionEnabled(const QJsonObject &root)
     return config::boolValue(value.toObject().value(QStringLiteral("enabled")));
 }
 
-/// @brief Checks if the configured command matches the current desktop environment.
+/// @brief 判断已配置的窗口检测命令是否匹配当前桌面环境。
+/// @param command 用户配置中的窗口检测命令。
+/// @return 匹配当前桌面环境时返回 true，否则返回 false。
 bool commandMatchesEnvironment(const QString &command)
 {
 #if defined(Q_OS_WIN)
-    Q_UNUSED(command);
-    return true;
+    return command.isEmpty();
 #else
-    if (command.isEmpty()) {
-        return false;
-    }
     const QString sessionType = detectWaylandSessionType();
     if (sessionType.isEmpty()) {
-        return !command.contains(QStringLiteral("wayland-detection"));
+        return command.isEmpty();
+    }
+    if (command.isEmpty()) {
+        return false;
     }
     return command.contains(sessionType);
 #endif

--- a/src/window_detection.cpp
+++ b/src/window_detection.cpp
@@ -97,6 +97,51 @@ QString existingAppConfigPath()
     return {};
 }
 
+/// @brief Detects the Wayland session type based on environment variables.
+/// @return "gnome", "kde", "hyprland", "niri" for known Wayland sessions, empty string for X11 or unknown.
+QString detectWaylandSessionType()
+{
+    const QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    const QString sessionType = env.value(QStringLiteral("XDG_SESSION_TYPE")).toLower();
+    if (sessionType != QStringLiteral("wayland")) {
+        return {};
+    }
+
+    const QString desktop = (env.value(QStringLiteral("XDG_CURRENT_DESKTOP"))
+        + QLatin1Char(':') + env.value(QStringLiteral("XDG_SESSION_DESKTOP"))
+        + QLatin1Char(':') + env.value(QStringLiteral("DESKTOP_SESSION")))
+        .toLower();
+
+    if (desktop.contains(QStringLiteral("gnome"))) {
+        return QStringLiteral("gnome");
+    }
+    if (desktop.contains(QStringLiteral("kde")) || desktop.contains(QStringLiteral("plasma"))) {
+        return QStringLiteral("kde");
+    }
+    if (desktop.contains(QStringLiteral("hyprland"))) {
+        return QStringLiteral("hyprland");
+    }
+    if (desktop.contains(QStringLiteral("niri"))) {
+        return QStringLiteral("niri");
+    }
+
+    return QStringLiteral("niri");
+}
+
+/// @brief Returns the appropriate window detection command for the current desktop environment.
+QString defaultWindowDetectionCommand()
+{
+#if defined(Q_OS_WIN)
+    return QString();
+#else
+    const QString sessionType = detectWaylandSessionType();
+    if (sessionType.isEmpty()) {
+        return QString();
+    }
+    return QStringLiteral("mark-shot-window-detection-") + sessionType;
+#endif
+}
+
 /// @brief Generates the default configuration JSON object structure.
 /// @return The default QJsonObject configuration root.
 QJsonObject defaultAppConfigRoot()
@@ -203,11 +248,7 @@ QJsonObject defaultAppConfigRoot()
 
     QJsonObject windowDetection;
     windowDetection.insert(QStringLiteral("enabled"), true);
-#if defined(Q_OS_WIN)
-    windowDetection.insert(QStringLiteral("command"), QString());
-#else
-    windowDetection.insert(QStringLiteral("command"), QStringLiteral("mark-shot-window-detection-niri"));
-#endif
+    windowDetection.insert(QStringLiteral("command"), defaultWindowDetectionCommand());
     windowDetection.insert(QStringLiteral("env"), QJsonObject());
     windowDetection.insert(QStringLiteral("timeoutMs"), 1000);
     root.insert(QStringLiteral("windowDetection"), windowDetection);
@@ -553,6 +594,24 @@ std::optional<bool> configuredWindowDetectionEnabled(const QJsonObject &root)
     return config::boolValue(value.toObject().value(QStringLiteral("enabled")));
 }
 
+/// @brief Checks if the configured command matches the current desktop environment.
+bool commandMatchesEnvironment(const QString &command)
+{
+#if defined(Q_OS_WIN)
+    Q_UNUSED(command);
+    return true;
+#else
+    if (command.isEmpty()) {
+        return false;
+    }
+    const QString sessionType = detectWaylandSessionType();
+    if (sessionType.isEmpty()) {
+        return !command.contains(QStringLiteral("wayland-detection"));
+    }
+    return command.contains(sessionType);
+#endif
+}
+
 /// @brief Reads and parses the window detection configuration from the application settings.
 /// @return A WindowDetectionConfig struct if configured and enabled, std::nullopt otherwise.
 std::optional<WindowDetectionConfig> readWindowDetectionConfig()
@@ -578,6 +637,9 @@ std::optional<WindowDetectionConfig> readWindowDetectionConfig()
         config.timeoutMs = std::clamp(*timeoutMs, kMinWindowDetectionTimeoutMs, kMaxWindowDetectionTimeoutMs);
     }
 
+    if (!commandMatchesEnvironment(config.command)) {
+        config.command = defaultWindowDetectionCommand();
+    }
     if (config.command.isEmpty()) {
         return std::nullopt;
     }


### PR DESCRIPTION
Previously the default window detection command was hardcoded to 'mark-shot-window-detection-niri', causing detection to fail on other Wayland desktop sessions (falling back to X11 enumeration which misses most windows).

Now:
- New helper detects current desktop environment at runtime
- Supported environments: GNOME, KDE Plasma, Hyprland, Niri
- Other Wayland sessions fallback to niri script
- X11 sessions use native X11 detection (empty command)
- Configured command is validated against current environment
- Automatically falls back to correct script if mismatch detected
- Does not modify user's config file (memory-only correction)