### PR TITLE
fix: show fcitx5 candidate window under Wayland layer-shell overlay

### DIFF
--- a/src/layer_shell_plugin.cpp
+++ b/src/layer_shell_plugin.cpp
@@ -138,6 +138,30 @@ public:
         return configureFloatingOverlayInternal(widget, screen, config, false);
     }
 
+    bool setLayer(QWidget *widget, markshot::layershell::Layer layer) override
+    {
+        if (!widget) {
+            markshot::debugLog("layershell", "setLayer failed: widget is null");
+            return false;
+        }
+        QWindow *nativeWindow = widget->windowHandle();
+        if (!nativeWindow) {
+            markshot::debugLog("layershell", "setLayer failed: no native QWindow");
+            return false;
+        }
+        LayerShellQt::Window *layerWindow = LayerShellQt::Window::get(nativeWindow);
+        if (!layerWindow) {
+            markshot::debugLog("layershell", "setLayer failed: no layer window");
+            return false;
+        }
+        layerWindow->setLayer(layer == markshot::layershell::Layer::Overlay
+                                  ? LayerShellQt::Window::LayerOverlay
+                                  : LayerShellQt::Window::LayerTop);
+        markshot::debugLog("layershell", "setLayer to %s",
+                           layer == markshot::layershell::Layer::Overlay ? "overlay" : "top");
+        return true;
+    }
+
 private:
     static bool configureFloatingOverlayInternal(
         QWidget *widget,

--- a/src/layer_shell_plugin_interface.h
+++ b/src/layer_shell_plugin_interface.h
@@ -15,6 +15,11 @@ enum class KeyboardInteractivity {
     OnDemand,
 };
 
+enum class Layer {
+    Top,
+    Overlay,
+};
+
 struct OverlayConfig {
     QString scope;
     KeyboardInteractivity keyboardInteractivity = KeyboardInteractivity::Exclusive;
@@ -43,11 +48,12 @@ public:
     virtual bool updateFloatingOverlay(QWidget *widget,
                                        QScreen *screen,
                                        const FloatingOverlayConfig &config) = 0;
+    virtual bool setLayer(QWidget *widget, Layer layer) = 0;
 };
 
 } // namespace markshot::layershell
 
-#define MARK_SHOT_LAYER_SHELL_PLUGIN_IID "dev.mark-shot.LayerShellPlugin/1.1"
+#define MARK_SHOT_LAYER_SHELL_PLUGIN_IID "dev.mark-shot.LayerShellPlugin/1.2"
 
 /// @brief Declares the interface for the layer shell plugin.
 Q_DECLARE_INTERFACE(markshot::layershell::PluginInterface, MARK_SHOT_LAYER_SHELL_PLUGIN_IID)

--- a/src/layer_shell_runtime.cpp
+++ b/src/layer_shell_runtime.cpp
@@ -137,7 +137,7 @@ bool updateFloatingOverlay(QWidget *widget, QScreen *screen, const FloatingOverl
     return plugin && plugin->updateFloatingOverlay(widget, screen, config);
 }
 
-bool setOverlayLayer(QWidget *widget, Layer layer)
+bool setLayer(QWidget *widget, Layer layer)
 {
     PluginInterface *plugin = loadPlugin();
     return plugin && plugin->setLayer(widget, layer);

--- a/src/layer_shell_runtime.cpp
+++ b/src/layer_shell_runtime.cpp
@@ -137,4 +137,10 @@ bool updateFloatingOverlay(QWidget *widget, QScreen *screen, const FloatingOverl
     return plugin && plugin->updateFloatingOverlay(widget, screen, config);
 }
 
+bool setOverlayLayer(QWidget *widget, Layer layer)
+{
+    PluginInterface *plugin = loadPlugin();
+    return plugin && plugin->setLayer(widget, layer);
+}
+
 } // namespace markshot::layershell

--- a/src/layer_shell_runtime.h
+++ b/src/layer_shell_runtime.h
@@ -7,6 +7,6 @@ namespace markshot::layershell {
 bool configureOverlay(QWidget *widget, QScreen *screen, const OverlayConfig &config);
 bool configureFloatingOverlay(QWidget *widget, QScreen *screen, const FloatingOverlayConfig &config);
 bool updateFloatingOverlay(QWidget *widget, QScreen *screen, const FloatingOverlayConfig &config);
-bool setOverlayLayer(QWidget *widget, Layer layer);
+bool setLayer(QWidget *widget, Layer layer);
 
 } // namespace markshot::layershell

--- a/src/layer_shell_runtime.h
+++ b/src/layer_shell_runtime.h
@@ -7,5 +7,6 @@ namespace markshot::layershell {
 bool configureOverlay(QWidget *widget, QScreen *screen, const OverlayConfig &config);
 bool configureFloatingOverlay(QWidget *widget, QScreen *screen, const FloatingOverlayConfig &config);
 bool updateFloatingOverlay(QWidget *widget, QScreen *screen, const FloatingOverlayConfig &config);
+bool setOverlayLayer(QWidget *widget, Layer layer);
 
 } // namespace markshot::layershell

--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -131,6 +131,7 @@ public:
     static std::optional<Tool> toolFromName(QString name);
     static QStringList supportedToolNames();
     bool configureLayerShell(QScreen *screen);
+    void updateLayerShellForIme();
     void startFullscreenAnnotation();
     void setImageNavigationEnabled(bool enabled);
     void setDefaultTool(Tool tool);

--- a/src/shot_window_annotation_painting.cpp
+++ b/src/shot_window_annotation_painting.cpp
@@ -579,6 +579,7 @@ void ShotWindow::beginTextAnnotation(QPointF imagePoint)
     m_textEditor->raise();
     updateTextEditorGeometry();
     m_textEditor->setFocus(Qt::MouseFocusReason);
+    updateLayerShellForIme();
     update();
 }
 
@@ -614,6 +615,7 @@ void ShotWindow::beginEditingSelectedTextAnnotation()
     const QRectF widgetRect = textContentRect(*annotation, true);
     m_textEditor->setGeometry(widgetRect.toAlignedRect().adjusted(0, 0, 1, 1));
     m_textEditor->setFocus(Qt::MouseFocusReason);
+    updateLayerShellForIme();
     update();
 }
 
@@ -629,6 +631,7 @@ void ShotWindow::commitTextEditor()
     m_textEditor->hide();
     m_textEditor->clear();
     setFocus(Qt::OtherFocusReason);
+    updateLayerShellForIme();
 
     if (m_editingTextAnnotationId.has_value()) {
         if (Annotation *annotation = annotationById(*m_editingTextAnnotationId)) {

--- a/src/shot_window_input.cpp
+++ b/src/shot_window_input.cpp
@@ -519,6 +519,7 @@ void ShotWindow::beginSelection(QPointF imagePoint)
     if (m_textEditor) {
         m_textEditor->hide();
         m_textEditor->clear();
+        updateLayerShellForIme();
     }
     if (m_openWithPanel) {
         m_openWithPanel->hide();

--- a/src/shot_window_modes.cpp
+++ b/src/shot_window_modes.cpp
@@ -476,6 +476,7 @@ bool ShotWindow::eventFilter(QObject *watched, QEvent *event)
             m_textEditor->hide();
             m_textEditor->clear();
             setFocus(Qt::OtherFocusReason);
+            updateLayerShellForIme();
             update();
             return true;
         }

--- a/src/shot_window_module.h
+++ b/src/shot_window_module.h
@@ -46,6 +46,7 @@
 #include <QFrame>
 #include <QGuiApplication>
 #include <QHBoxLayout>
+#include <QInputMethod>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -639,10 +639,13 @@ void ShotWindow::updateLayerShellForIme()
         this, imeActive ? markshot::layershell::Layer::Top : markshot::layershell::Layer::Overlay);
     if (imeActive) {
         // Layer change triggers an async wl_surface::configure roundtrip from
-        // KWin. singleShot(0) defers the cursor-rectangle republish to the next
-        // event-loop tick, which is empirically sufficient on KWin 6.x: the
-        // compositor applies the layer switch synchronously in its event source
-        // before processing the text-input-v3 enable request that follows.
+        // the compositor. singleShot(0) defers the cursor-rectangle republish
+        // to the next event-loop tick. This is sufficient across mainstream
+        // compositors (KWin, wlroots, Smithay) because set_layer and
+        // set_cursor_rectangle share the same ordered wl_display connection,
+        // and compositors apply layer changes synchronously in their event
+        // source rather than deferring to render frame. Fallback if needed:
+        // hook LayerShellQt::Window::layerChanged signal.
         QTimer::singleShot(0, this, [this]() {
             if (m_textEditor && m_textEditor->isVisible()) {
                 if (QInputMethod *im = QGuiApplication::inputMethod()) {

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -632,6 +632,22 @@ bool ShotWindow::configureLayerShell(QScreen *screen)
          true});
 }
 
+void ShotWindow::updateLayerShellForIme()
+{
+    const bool imeActive = m_textEditor && m_textEditor->isVisible();
+    markshot::layershell::setOverlayLayer(
+        this, imeActive ? markshot::layershell::Layer::Top : markshot::layershell::Layer::Overlay);
+    if (imeActive) {
+        QTimer::singleShot(0, this, [this]() {
+            if (m_textEditor && m_textEditor->isVisible()) {
+                if (QInputMethod *im = QGuiApplication::inputMethod()) {
+                    im->update(Qt::ImCursorRectangle);
+                }
+            }
+        });
+    }
+}
+
 void ShotWindow::startFullscreenAnnotation()
 {
     enterFullscreenAnnotation(true);

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -635,9 +635,14 @@ bool ShotWindow::configureLayerShell(QScreen *screen)
 void ShotWindow::updateLayerShellForIme()
 {
     const bool imeActive = m_textEditor && m_textEditor->isVisible();
-    markshot::layershell::setOverlayLayer(
+    markshot::layershell::setLayer(
         this, imeActive ? markshot::layershell::Layer::Top : markshot::layershell::Layer::Overlay);
     if (imeActive) {
+        // Layer change triggers an async wl_surface::configure roundtrip from
+        // KWin. singleShot(0) defers the cursor-rectangle republish to the next
+        // event-loop tick, which is empirically sufficient on KWin 6.x: the
+        // compositor applies the layer switch synchronously in its event source
+        // before processing the text-input-v3 enable request that follows.
         QTimer::singleShot(0, this, [this]() {
             if (m_textEditor && m_textEditor->isVisible()) {
                 if (QInputMethod *im = QGuiApplication::inputMethod()) {


### PR DESCRIPTION
ShotWindow uses layer-shell LayerOverlay with ExclusiveZone(-1) for fullscreen capture coverage. On Wayland, fcitx5 places its candidate window via zwp_input_panel_v1, whose stacking level sits below the Overlay layer, so the panel was hidden behind the capture surface.

Extend PluginInterface with a Layer enum and setLayer() virtual, bump the plugin IID 1.1 -> 1.2, and implement the forwarder in layer_shell_runtime. ShotWindow now drops to LayerTop while the text editor is visible and restores LayerOverlay when editing ends, letting the input panel surface stack above the capture window.

The layer switch triggers a KWin surface reconfigure that can drop the text-input-v3 cursor rectangle reported on focus-in, so the first keystroke placed the candidate window at the screen origin. After the layer change, invoke QInputMethod::update(ImCursorRectangle) on the next event loop tick to re-publish the cursor rectangle.

Refs: #1