### PR TITLE
feat(window-detection): support z-order based window selection

### DIFF
--- a/scripts/mark-shot-window-detection-gnome
+++ b/scripts/mark-shot-window-detection-gnome
@@ -92,10 +92,12 @@ def gnome_window_json():
 def main():
     data = gnome_window_json()
     capture = capture_rect()
+    windows = data.get("windows", [])
+    total = len(windows)
     result = []
     seen = set()
 
-    for window in data.get("windows", []):
+    for idx, window in enumerate(windows):
         if not isinstance(window, dict):
             continue
         rect = adjusted_rect(window)
@@ -111,6 +113,7 @@ def main():
             "y": rect[1],
             "width": rect[2],
             "height": rect[3],
+            "zOrder": total - 1 - idx,
         }
         for key in ("title", "class", "instance", "monitor", "workspace"):
             if key in window:

--- a/scripts/mark-shot-window-detection-hyprland
+++ b/scripts/mark-shot-window-detection-hyprland
@@ -188,7 +188,7 @@ def client_rect(client):
     return x, y, width, height
 
 
-def append_client(result, seen, client, capture, targets):
+def append_client(result, seen, client, capture, targets, z_order):
     if client.get("mapped") is False:
         return
     if client.get("hidden") is True:
@@ -218,6 +218,7 @@ def append_client(result, seen, client, capture, targets):
         "y": rect[1],
         "width": rect[2],
         "height": rect[3],
+        "zOrder": z_order,
     }
     for key_name in ("address", "class", "title", "initialClass", "initialTitle"):
         value = client.get(key_name)
@@ -248,9 +249,9 @@ def main():
     result = []
     seen = set()
 
-    for client in clients:
+    for idx, client in enumerate(clients):
         if isinstance(client, dict):
-            append_client(result, seen, client, capture, targets)
+            append_client(result, seen, client, capture, targets, idx)
 
     print(json.dumps({"compositor": "hyprland", "windows": result}, separators=(",", ":")))
 

--- a/scripts/mark-shot-window-detection-kde
+++ b/scripts/mark-shot-window-detection-kde
@@ -256,7 +256,7 @@ def script_source(token):
         return false;
     }}
 
-    function appendWindow(result, seen, window) {{
+    function appendWindow(result, seen, window, zOrder) {{
         if (!window || shouldSkip(window)) {{
             return;
         }}
@@ -274,6 +274,7 @@ def script_source(token):
             y: rect.y,
             width: rect.width,
             height: rect.height,
+            zOrder: zOrder,
         }};
         const title = value(window, "caption");
         const resourceClass = value(window, "resourceClass") || value(window, "windowClass");
@@ -308,7 +309,7 @@ def script_source(token):
     const seen = {{}};
     const windows = workspace.stackingOrder || [];
     for (let i = 0; i < windows.length; i += 1) {{
-        appendWindow(result, seen, windows[i]);
+        appendWindow(result, seen, windows[i], i);
     }}
     print("{MARKER} " + token + " " + JSON.stringify({{compositor: "kde", windows: result}}));
 }})();

--- a/src/capture_session_launcher.cpp
+++ b/src/capture_session_launcher.cpp
@@ -29,7 +29,7 @@ struct CapturedScreenFrame {
     QImage image;
     QString outputName;
     QRect sourceGeometry;
-    QVector<QRect> windowGeometries;
+    QVector<markshot::WindowInfo> windowInfos;
     bool detectWindows = false;
 };
 
@@ -165,7 +165,7 @@ ShotWindow *showCapturedWindow(QScreen *screen,
                                QImage image,
                                QString outputName,
                                QRect sourceGeometry,
-                               QVector<QRect> windowGeometries,
+                               QVector<markshot::WindowInfo> windowInfos,
                                bool detectWindows,
                                bool allOutputs,
                                bool useRegularWindow,
@@ -173,7 +173,7 @@ ShotWindow *showCapturedWindow(QScreen *screen,
                                const markshot::DefaultTools &defaultTools)
 {
     ShotWindow *window =
-        new ShotWindow(std::move(image), std::move(outputName), sourceGeometry, std::move(windowGeometries), detectWindows);
+        new ShotWindow(std::move(image), std::move(outputName), sourceGeometry, std::move(windowInfos), detectWindows);
     window->setDefaultTools(defaultTools.normal, defaultTools.fullscreen);
     if (markshot::shouldApplyDefaultColor(defaultTools)) {
         window->setDefaultColor(defaultTools.color);
@@ -227,9 +227,9 @@ ShotWindow *showCaptureWindow(QScreen *screen,
     const QRect captureGeometry = allOutputs ? virtualScreensGeometry() : (screen ? screen->geometry() : QRect());
     const QString outputName = (!allOutputs && screen) ? screen->name() : QString();
     const bool detectWindows = markshot::windowDetectionEnabled();
-    const QVector<QRect> windowGeometries = detectWindows
-        ? markshot::collectConfiguredWindowGeometries(captureGeometry, outputName, allOutputs)
-        : QVector<QRect>();
+    const QVector<markshot::WindowInfo> windowInfos = detectWindows
+        ? markshot::collectConfiguredWindowInfos(captureGeometry, outputName, allOutputs)
+        : QVector<markshot::WindowInfo>();
     CaptureRequest request;
     request.preferredOutputName = outputName;
     request.sourceGeometry = captureGeometry;
@@ -251,7 +251,7 @@ ShotWindow *showCaptureWindow(QScreen *screen,
                               std::move(capture.image),
                               capturedOutputName,
                               sourceGeometry,
-                              windowGeometries,
+                              windowInfos,
                               detectWindows,
                               allOutputs,
                               useRegularWindow,
@@ -328,14 +328,14 @@ ShotWindow *showDisplayCaptureTarget(const markshot::display_capture::Target &ta
     }
 
     const bool detectWindows = markshot::windowDetectionEnabled();
-    const QVector<QRect> windowGeometries = detectWindows
-        ? markshot::collectConfiguredWindowGeometries(target.geometry, target.outputName, target.allOutputs)
-        : QVector<QRect>();
+    const QVector<markshot::WindowInfo> windowInfos = detectWindows
+        ? markshot::collectConfiguredWindowInfos(target.geometry, target.outputName, target.allOutputs)
+        : QVector<markshot::WindowInfo>();
     return showCapturedWindow(screen,
                               target.image,
                               target.outputName,
                               target.geometry,
-                              windowGeometries,
+                              windowInfos,
                               detectWindows,
                               target.allOutputs,
                               useRegularWindow,
@@ -472,9 +472,9 @@ QVector<CapturedScreenFrame> captureScreensIndividually(const QList<QScreen *> &
 
         const QRect captureGeometry = screen->geometry();
         const QString outputName = screen->name();
-        const QVector<QRect> windowGeometries = detectWindows
-            ? markshot::collectConfiguredWindowGeometries(captureGeometry, outputName, false)
-            : QVector<QRect>();
+        const QVector<markshot::WindowInfo> windowInfos = detectWindows
+            ? markshot::collectConfiguredWindowInfos(captureGeometry, outputName, false)
+            : QVector<markshot::WindowInfo>();
 
         CaptureRequest request;
         request.preferredOutputName = outputName;
@@ -507,7 +507,7 @@ QVector<CapturedScreenFrame> captureScreensIndividually(const QList<QScreen *> &
         frame.sourceGeometry = capture.sourceGeometry.isValid() && !capture.sourceGeometry.isEmpty()
             ? capture.sourceGeometry
             : captureGeometry;
-        frame.windowGeometries = windowGeometries;
+        frame.windowInfos = windowInfos;
         frame.detectWindows = detectWindows;
         markshot::debugLog("capture-session",
                            "【截图会话】【缩放诊断】individual-result screen=%s output=%s "
@@ -556,7 +556,7 @@ QVector<QPointer<ShotWindow>> showCaptureWindowsFromIndividualFrames(const QList
                                                 std::move(frame.image),
                                                 std::move(frame.outputName),
                                                 frame.sourceGeometry,
-                                                std::move(frame.windowGeometries),
+                                                std::move(frame.windowInfos),
                                                 frame.detectWindows,
                                                 false,
                                                 useRegularWindow,
@@ -649,14 +649,14 @@ QVector<QPointer<ShotWindow>> showCaptureWindowsFromSingleFrame(const QList<QScr
                            static_cast<qreal>(screenImage.width()) / std::max(1, screenGeometry.width()),
                            static_cast<qreal>(screenImage.height()) / std::max(1, screenGeometry.height()));
 
-        const QVector<QRect> windowGeometries = detectWindows
-            ? markshot::collectConfiguredWindowGeometries(screenGeometry, screen->name(), false)
-            : QVector<QRect>();
+        const QVector<markshot::WindowInfo> windowInfos = detectWindows
+            ? markshot::collectConfiguredWindowInfos(screenGeometry, screen->name(), false)
+            : QVector<markshot::WindowInfo>();
         ShotWindow *window = showCapturedWindow(screen,
                                                 std::move(screenImage),
                                                 screen->name(),
                                                 screenGeometry,
-                                                windowGeometries,
+                                                windowInfos,
                                                 detectWindows,
                                                 false,
                                                 useRegularWindow,

--- a/src/screen_capture.h
+++ b/src/screen_capture.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "window_detection.h"
+
 #include <QImage>
 #include <QRect>
 #include <QString>
@@ -38,6 +40,7 @@ CaptureResult captureScreenFrame(const CaptureRequest &request);
 void stopActiveScreencastCapture();
 // Returns visible X11 window frames for selection snapping/highlighting.
 QVector<QRect> enumerateX11WindowGeometries();
+QVector<markshot::WindowInfo> enumerateX11WindowInfos();
 bool isGnomeWaylandSession();
 bool hasGnomeScrollHelper();
 bool hasGnomeScrollPreviewHelper();

--- a/src/screen_capture_platform_api.cpp
+++ b/src/screen_capture_platform_api.cpp
@@ -111,14 +111,14 @@ QVector<QRect> enumerateX11WindowGeometries()
 }
 
 /// @brief Enumerates the info of all open X11 windows.
-/// @return A vector of WindowInfo representing the window geometries (without z-order for X11).
+/// @return A vector of WindowInfo with z-order based on _NET_CLIENT_LIST_STACKING order (bottom-to-top).
 QVector<markshot::WindowInfo> enumerateX11WindowInfos()
 {
     QVector<markshot::WindowInfo> results;
     const QVector<QRect> geometries = enumerateX11WindowGeometries();
     results.reserve(geometries.size());
-    for (const QRect &rect : geometries) {
-        results.append(markshot::WindowInfo{rect, std::nullopt});
+    for (int i = 0; i < geometries.size(); ++i) {
+        results.append(markshot::WindowInfo{geometries[i], i});
     }
     return results;
 }

--- a/src/screen_capture_platform_api.cpp
+++ b/src/screen_capture_platform_api.cpp
@@ -110,6 +110,19 @@ QVector<QRect> enumerateX11WindowGeometries()
     return results;
 }
 
+/// @brief Enumerates the info of all open X11 windows.
+/// @return A vector of WindowInfo representing the window geometries (without z-order for X11).
+QVector<markshot::WindowInfo> enumerateX11WindowInfos()
+{
+    QVector<markshot::WindowInfo> results;
+    const QVector<QRect> geometries = enumerateX11WindowGeometries();
+    results.reserve(geometries.size());
+    for (const QRect &rect : geometries) {
+        results.append(markshot::WindowInfo{rect, std::nullopt});
+    }
+    return results;
+}
+
 bool isGnomeWaylandSession()
 {
 #ifdef MARK_SHOT_WITH_DBUS

--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -14,6 +14,7 @@
 #include "display_capture/display_capture_target.h"
 #include "toolbar_appearance_config.h"
 #include "ui/theme.h"
+#include "window_detection.h"
 
 #include <array>
 #include <optional>
@@ -125,7 +126,7 @@ public:
     explicit ShotWindow(QImage frozenFrame,
                         QString outputName,
                         QRect sourceGeometry = {},
-                        QVector<QRect> windowGeometries = {},
+                        QVector<markshot::WindowInfo> windowInfos = {},
                         bool windowDetectionEnabled = true,
                         QWidget *parent = nullptr);
     static std::optional<Tool> toolFromName(QString name);
@@ -304,7 +305,7 @@ private:
     void initializeTransientPanels();
     void initializeTextEditor();
     void initializeLaserTimer();
-    void initializeWindowDetection(QVector<QRect> windowGeometries, bool enabled);
+    void initializeWindowDetection(QVector<markshot::WindowInfo> windowInfos, bool enabled);
     QPushButton *addToolbarButton(Action action, const QString &shortcutText, QWidget *parentToolbar = nullptr);
     QVector<DesktopApp> imageDesktopApps() const;
     QVector<ExtensionCommand> extensionCommands(QString *errorMessage = nullptr) const;
@@ -691,7 +692,7 @@ private:
     std::optional<int> m_editingTextAnnotationId;
     QVector<HistorySnapshot> m_undoStack;
     QVector<HistorySnapshot> m_redoStack;
-    QVector<QRect> m_windowRects;
+    QVector<markshot::WindowInfo> m_windowInfos;
     std::optional<QRect> m_hoveredWindowRect;
     QPointF m_selectionClickStart;
 };

--- a/src/shot_window_input.cpp
+++ b/src/shot_window_input.cpp
@@ -40,20 +40,37 @@ void ShotWindow::mouseMoveEvent(QMouseEvent *event)
     }
 
     if (m_mode == Mode::Selecting && !m_dragging) {
-        std::optional<QRect> best;
-        qint64 bestArea = std::numeric_limits<qint64>::max();
+        std::optional<markshot::WindowInfo> best;
         const QPoint imgPt = imagePoint.toPoint();
-        for (const QRect &r : std::as_const(m_windowRects)) {
-            if (r.contains(imgPt)) {
-                qint64 area = static_cast<qint64>(r.width()) * r.height();
+        bool useZOrder = false;
+
+        for (const markshot::WindowInfo &info : std::as_const(m_windowInfos)) {
+            if (!info.rect.contains(imgPt)) {
+                continue;
+            }
+
+            if (!best.has_value()) {
+                useZOrder = info.zOrder.has_value();
+                best = info;
+                continue;
+            }
+
+            if (useZOrder) {
+                if (info.zOrder > best->zOrder) {
+                    best = info;
+                }
+            } else {
+                qint64 area = static_cast<qint64>(info.rect.width()) * info.rect.height();
+                qint64 bestArea = static_cast<qint64>(best->rect.width()) * best->rect.height();
                 if (area < bestArea) {
-                    bestArea = area;
-                    best = r;
+                    best = info;
                 }
             }
         }
-        if (best != m_hoveredWindowRect) {
-            m_hoveredWindowRect = best;
+
+        const std::optional<QRect> bestRect = best ? std::optional(best->rect) : std::nullopt;
+        if (bestRect != m_hoveredWindowRect) {
+            m_hoveredWindowRect = bestRect;
             update();
         }
     }

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -77,7 +77,7 @@ QStringList ShotWindow::supportedToolNames()
 ShotWindow::ShotWindow(QImage frozenFrame,
                        QString outputName,
                        QRect sourceGeometry,
-                       QVector<QRect> windowGeometries,
+                       QVector<markshot::WindowInfo> windowInfos,
                        bool windowDetectionEnabled,
                        QWidget *parent)
     : QWidget(parent)
@@ -401,7 +401,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
     initializeTransientPanels();
     initializeTextEditor();
     initializeLaserTimer();
-    initializeWindowDetection(std::move(windowGeometries), windowDetectionEnabled);
+    initializeWindowDetection(std::move(windowInfos), windowDetectionEnabled);
 }
 
 void ShotWindow::initializeToolbar()
@@ -587,25 +587,28 @@ void ShotWindow::initializeLaserTimer()
     connect(m_laserTimer, &QTimer::timeout, this, [this] { cleanupLaserStrokes(); });
 }
 
-void ShotWindow::initializeWindowDetection(QVector<QRect> windowGeometries, bool enabled)
+void ShotWindow::initializeWindowDetection(QVector<markshot::WindowInfo> windowInfos, bool enabled)
 {
     if (!enabled) {
         return;
     }
 
-    if (windowGeometries.isEmpty()) {
+    if (windowInfos.isEmpty()) {
 #if defined(Q_OS_WIN)
-        windowGeometries = markshot::windows::enumerateWindowGeometries();
+        windowInfos = markshot::windows::enumerateWindowInfos();
 #else
-        windowGeometries = enumerateX11WindowGeometries();
+        windowInfos = enumerateX11WindowInfos();
 #endif
     }
-    for (const QRect &windowGeometry : std::as_const(windowGeometries)) {
-        const QRect imageRect = windowGeometryToImageRect(windowGeometry,
+    for (const markshot::WindowInfo &info : std::as_const(windowInfos)) {
+        const QRect imageRect = windowGeometryToImageRect(info.rect,
                                                           m_sourceGeometry,
                                                           m_frozenFrame.size());
         if (imageRect.width() > 1 && imageRect.height() > 1) {
-            m_windowRects.append(imageRect);
+            markshot::WindowInfo converted;
+            converted.rect = imageRect;
+            converted.zOrder = info.zOrder;
+            m_windowInfos.append(converted);
         }
     }
 }

--- a/src/window_detection.cpp
+++ b/src/window_detection.cpp
@@ -484,6 +484,27 @@ std::optional<QRect> rectFromWindowObject(const QJsonObject &object)
     return QRect(*x, *y, *width, *height);
 }
 
+/// @brief Attempts to extract a WindowInfo from a JSON window object.
+/// @param object The JSON object representing a window's metadata.
+/// @return A WindowInfo if a geometry was successfully extracted, std::nullopt otherwise.
+std::optional<WindowInfo> windowInfoFromWindowObject(const QJsonObject &object)
+{
+    std::optional<QRect> rect = rectFromWindowObject(object);
+    if (!rect.has_value()) {
+        return std::nullopt;
+    }
+
+    WindowInfo info;
+    info.rect = *rect;
+
+    const QJsonValue zOrderValue = object.value(QStringLiteral("zOrder"));
+    if (zOrderValue.isDouble()) {
+        info.zOrder = static_cast<int>(zOrderValue.toDouble());
+    }
+
+    return info;
+}
+
 /// @brief Normalizes a rectangle and appends it to the list of geometries if valid and not a duplicate.
 /// @param rects Pointer to the destination vector of rectangles.
 /// @param rect The rectangle geometry to add.
@@ -501,12 +522,32 @@ void appendValidRect(QVector<QRect> *rects, QRect rect)
     }
 }
 
+/// @brief Normalizes a WindowInfo and appends it to the list if valid and not a duplicate.
+/// @param infos Pointer to the destination vector of WindowInfo.
+/// @param info The WindowInfo to add.
+void appendValidWindowInfo(QVector<WindowInfo> *infos, WindowInfo info)
+{
+    if (!infos) {
+        return;
+    }
+    info.rect = info.rect.normalized();
+    if (info.rect.width() <= 1 || info.rect.height() <= 1) {
+        return;
+    }
+    for (const WindowInfo &existing : *infos) {
+        if (existing.rect == info.rect) {
+            return;
+        }
+    }
+    infos->append(info);
+}
+
 /// @brief Parses the standard output of the window detection script.
 /// @param output The raw byte array output from the script.
-/// @return A vector of parsed window bounding rectangles.
-QVector<QRect> parseWindowDetectionOutput(const QByteArray &output)
+/// @return A vector of parsed window info with optional z-order.
+QVector<WindowInfo> parseWindowDetectionOutput(const QByteArray &output)
 {
-    QVector<QRect> results;
+    QVector<WindowInfo> results;
 
     QJsonParseError parseError;
     const QJsonDocument document = QJsonDocument::fromJson(output, &parseError);
@@ -527,23 +568,29 @@ QVector<QRect> parseWindowDetectionOutput(const QByteArray &output)
             windows = root.value(QStringLiteral("windows")).toArray();
         } else if (root.value(QStringLiteral("windowGeometries")).isArray()) {
             windows = root.value(QStringLiteral("windowGeometries")).toArray();
-        } else if (const std::optional<QRect> rect = rectFromWindowObject(root)) {
-            appendValidRect(&results, *rect);
+        } else if (const std::optional<WindowInfo> info = windowInfoFromWindowObject(root)) {
+            appendValidWindowInfo(&results, *info);
             return results;
         }
     }
 
     for (const QJsonValue &value : windows) {
-        std::optional<QRect> rect;
+        std::optional<WindowInfo> info;
         if (value.isObject()) {
-            rect = rectFromWindowObject(value.toObject());
+            info = windowInfoFromWindowObject(value.toObject());
         } else if (value.isArray()) {
-            rect = rectFromArray(value.toArray());
+            std::optional<QRect> rect = rectFromArray(value.toArray());
+            if (rect.has_value()) {
+                info = WindowInfo{*rect, std::nullopt};
+            }
         } else if (value.isString()) {
-            rect = rectFromGeometryText(value.toString());
+            std::optional<QRect> rect = rectFromGeometryText(value.toString());
+            if (rect.has_value()) {
+                info = WindowInfo{*rect, std::nullopt};
+            }
         }
-        if (rect.has_value()) {
-            appendValidRect(&results, *rect);
+        if (info.has_value()) {
+            appendValidWindowInfo(&results, *info);
         }
     }
 
@@ -687,12 +734,12 @@ bool windowDetectionEnabled()
     return configuredWindowDetectionEnabled(*root).value_or(true);
 }
 
-/// @brief Collects the window geometries detected by running the configured external script/command.
+/// @brief Collects the window info detected by running the configured external script/command.
 /// @param captureGeometry The current screen or capture area geometry.
 /// @param outputName The name of the preferred display output.
 /// @param allOutputs Flag indicating whether capturing should target all outputs.
-/// @return A vector of detected window bounding rectangles.
-QVector<QRect> collectConfiguredWindowGeometries(const QRect &captureGeometry,
+/// @return A vector of detected window info with optional z-order.
+QVector<WindowInfo> collectConfiguredWindowInfos(const QRect &captureGeometry,
                                                  const QString &outputName,
                                                  bool allOutputs)
 {
@@ -734,7 +781,7 @@ QVector<QRect> collectConfiguredWindowGeometries(const QRect &captureGeometry,
         return {};
     }
 
-    const QVector<QRect> windows = parseWindowDetectionOutput(process.readAllStandardOutput());
+    const QVector<WindowInfo> windows = parseWindowDetectionOutput(process.readAllStandardOutput());
     markshot::debugLog("window-detection", "script returned windows=%d", static_cast<int>(windows.size()));
     return windows;
 }

--- a/src/window_detection.h
+++ b/src/window_detection.h
@@ -3,15 +3,21 @@
 #include <QRect>
 #include <QString>
 #include <QVector>
+#include <optional>
 
 namespace markshot {
+
+struct WindowInfo {
+    QRect rect;
+    std::optional<int> zOrder;
+};
 
 QString markShotConfigDir();
 QString appConfigPath();
 bool ensureAppConfigFile();
 bool windowDetectionEnabled();
 
-QVector<QRect> collectConfiguredWindowGeometries(const QRect &captureGeometry,
+QVector<WindowInfo> collectConfiguredWindowInfos(const QRect &captureGeometry,
                                                  const QString &outputName,
                                                  bool allOutputs);
 

--- a/src/windows_integration.cpp
+++ b/src/windows_integration.cpp
@@ -230,16 +230,28 @@ QVector<QRect> enumerateWindowGeometries()
     return windows;
 }
 
-/// @brief Enumerates the info of all visible windows.
-/// @return A vector of WindowInfo representing the window geometries (without z-order for Windows).
+/// @brief Enumerates the info of all visible windows with z-order.
+/// @return A vector of WindowInfo with z-order based on GetTopWindow chain (bottom-to-top, higher = topmost).
 QVector<markshot::WindowInfo> enumerateWindowInfos()
 {
     QVector<markshot::WindowInfo> results;
-    const QVector<QRect> geometries = enumerateWindowGeometries();
-    results.reserve(geometries.size());
-    for (const QRect &rect : geometries) {
-        results.append(markshot::WindowInfo{rect, std::nullopt});
+#if defined(Q_OS_WIN)
+    // GetTopWindow + GW_HWNDNEXT gives deterministic top-to-bottom z-order,
+    // unlike EnumWindows which does not guarantee any specific order.
+    int zOrder = 0;
+    for (HWND hwnd = GetTopWindow(nullptr); hwnd != nullptr; hwnd = GetWindow(hwnd, GW_HWNDNEXT)) {
+        QRect geometry;
+        if (isWindowCandidate(hwnd, &geometry) &&
+            !std::any_of(results.begin(), results.end(),
+                         [&](const markshot::WindowInfo &info) { return info.rect == geometry; })) {
+            results.append(markshot::WindowInfo{geometry, zOrder++});
+        }
     }
+    // Reverse z-order to match Linux convention (higher = topmost)
+    for (auto &info : results) {
+        info.zOrder = zOrder - 1 - *info.zOrder;
+    }
+#endif
     return results;
 }
 

--- a/src/windows_integration.cpp
+++ b/src/windows_integration.cpp
@@ -230,6 +230,19 @@ QVector<QRect> enumerateWindowGeometries()
     return windows;
 }
 
+/// @brief Enumerates the info of all visible windows.
+/// @return A vector of WindowInfo representing the window geometries (without z-order for Windows).
+QVector<markshot::WindowInfo> enumerateWindowInfos()
+{
+    QVector<markshot::WindowInfo> results;
+    const QVector<QRect> geometries = enumerateWindowGeometries();
+    results.reserve(geometries.size());
+    for (const QRect &rect : geometries) {
+        results.append(markshot::WindowInfo{rect, std::nullopt});
+    }
+    return results;
+}
+
 void setExcludedFromCapture(QWidget *widget, bool excluded)
 {
 #if defined(Q_OS_WIN)

--- a/src/windows_integration.h
+++ b/src/windows_integration.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "window_detection.h"
+
 #include <QRect>
 #include <QVector>
 
@@ -9,6 +11,7 @@ class QScreen;
 namespace markshot::windows {
 
 QVector<QRect> enumerateWindowGeometries();
+QVector<markshot::WindowInfo> enumerateWindowInfos();
 void setExcludedFromCapture(QWidget *widget, bool excluded = true);
 void showFullScreenOnScreen(QWidget *widget, QScreen *screen);
 /// @brief 将窗口切换为 Windows 原生置顶或取消置顶。


### PR DESCRIPTION
Replace area-based heuristic with proper z-order for window selection. The top-most window under the cursor is now selected regardless of size.

| Before | After |
|----------|---------|
| <video src="https://github.com/user-attachments/assets/103c823b-4b14-4300-a821-13ea46b32b95" width="160" height="90" /> |  <video src="https://github.com/user-attachments/assets/0eaa8c6a-50ff-4bad-a44a-38c64a344908" width="160" height="90" /> |

| Platform | z-order | Source |
|----------|---------|--------|
| GNOME Wayland | ✅ | Script enumeration index |
| X11 | ✅ | [_NET_CLIENT_LIST_STACKING](https://specifications.freedesktop.org/wm-spec/latest/ar01s03.html) (EWMH spec) |
| KDE Wayland | ✅ | [workspace.stackingOrder](https://develop.kde.org/docs/plasma/kwin/api/) (KWin API) |
| Hyprland | ✅ | hyprctl clients ([source code](https://github.com/hyprwm/Hyprland/blob/049595e196db4a4ab162ce58aadd016e929327c8/src/Compositor.cpp#L1193C1-L1194C16)) |
| Windows | ✅ | [GetTopWindow](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-gettopwindow) (Win32 API) |
| Niri | ❌ | N/A — tiling compositor, windows don't overlap |

> [!NOTE]
> Tested on GNOME Wayland — works as expected with overlapping windows. Other platforms are untested. Help wanted for X11, KDE, Hyprland, and Windows.
> - [x] **GNOME Wayland** — Verified
> - [ ] **X11** — Needs verification
> - [ ] **KDE Wayland** — Needs verification
> - [ ] **Hyprland** — Needs verification
> - [ ] **Windows** — Needs verification
> - [ ] **Niri** — Needs verification