### PR TITLE
fix: prevent text editor width shrinking on fractional scale

### DIFF
--- a/src/shot_window_annotation_painting.cpp
+++ b/src/shot_window_annotation_painting.cpp
@@ -634,8 +634,6 @@ void ShotWindow::commitTextEditor()
         if (Annotation *annotation = annotationById(*m_editingTextAnnotationId)) {
             pushHistorySnapshot();
             annotation->text = text;
-            annotation->rect = QRectF(widgetToImage(editorGeometry.topLeft()),
-                                      widgetToImage(editorGeometry.bottomRight())).normalized();
             annotation->fontFamily = m_textEditor->font().family();
             annotation->rect = textContentRect(*annotation, false);
             if (!annotation->points.isEmpty()) {


### PR DESCRIPTION
When editing an existing text annotation, the widget→image→widget round-trip through widgetToImage() accumulated floating-point precision loss under fractional DPI scaling (e.g. GNOME Wayland 1.25x/1.5x/1.75x).

Each edit-commit cycle produced a slightly smaller rect width, causing visible shrinking of the text bounding box.

Fix by removing the intermediate widgetToImage() conversion and letting textContentRect() recalculate the image-space rect directly from the text content, preserving the original anchor point.