### PR TITLE
feat: add Nix flake support and NixOS integration docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 compile_commands.json
 CMakeCache.txt
+result
 CMakeFiles/
 cmake_install.cmake
 install_manifest.txt

--- a/README.md
+++ b/README.md
@@ -682,6 +682,22 @@ yay -S mark-shot-bin
 
 `mark-shot` compiles from source; `mark-shot-bin` downloads the prebuilt pacman package from GitHub Releases.
 
+##### NixOS
+NixOS users can install mark-shot by adding it as a Flake input:
+```nix
+# flake.nix
+mark-shot = {
+  url = "github:jswysnemc/mark-shot";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+
+# home-manager
+home.packages = with pkgs; [
+  # other user packages
+  inputs.mark-shot.packages.${pkgs.stdenv.hostPlatform.system}.default
+]
+```
+
 ##### Other Distributions (Pre-built Packages)
 For other distributions (such as Debian, Ubuntu, or Fedora), download the compiled package from the Releases page and install it via:
 - **Debian / Ubuntu**:
@@ -852,6 +868,12 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
 
 # Build
 cmake --build build
+```
+
+Or build with Nix:
+
+```bash
+nix build
 ```
 
 LayerShellQt is detected automatically. When found, full Wayland layer-shell support is enabled. When absent, the build succeeds and falls back to standard fullscreen windows at runtime.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -598,6 +598,22 @@ yay -S mark-shot-bin
 
 `mark-shot` 从源码编译；`mark-shot-bin` 从 GitHub Releases 下载预编译 pacman 包安装。
 
+##### NixOS
+NixOS 用户可以通过添加 Flake input 来进行安装
+```nix
+# flake.nix
+mark-shot = {
+  url = "github:jswysnemc/mark-shot";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+
+# home-manager
+home.packages = with pkgs; [
+  # 其他用户应用
+  inputs.mark-shot.packages.${pkgs.stdenv.hostPlatform.system}.default
+]
+```
+
 ##### 其他发行版 (预编译安装包)
 对于其他发行版（如 Ubuntu, Debian, Fedora），请在 Releases 页面下载编译好的安装包并运行以下命令安装：
 - **Debian / Ubuntu**:
@@ -874,6 +890,12 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
 
 # 执行编译
 cmake --build build
+```
+
+或者使用 nix
+
+```bash
+nix build
 ```
 
 LayerShellQt 会被自动检测。找到时启用完整 Wayland layer-shell 支持；未找到时编译照常成功，运行时自动降级为标准全屏窗口。

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,78 @@
+{
+  description = "Mark Shot - a Qt6 screenshot & annotation tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        qtModules = with pkgs; [
+          qt6.qtbase
+          qt6.qtdeclarative
+          qt6.qttools
+          qt6.qtshadertools
+          qt6.qtsvg
+          qt6.qtmultimedia
+          qt6.qtwayland
+          qt6.qt5compat
+          qt6.qtimageformats
+          qt6.qtcharts
+        ];
+
+        mark-shot = pkgs.stdenv.mkDerivation {
+          pname = "mark-shot";
+          version = "0.1.32";
+
+          src = self;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+            qt6.wrapQtAppsHook
+          ];
+
+          buildInputs = qtModules ++ [
+            pkgs.kdePackages.layer-shell-qt
+            pkgs.libportal
+            pkgs.pipewire
+            pkgs.libxcb
+          ];
+
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DMARK_SHOT_WITH_LIBPORTAL=ON"
+          ];
+        };
+      in
+      {
+        packages = rec {
+          default = mark-shot;
+          inherit mark-shot;
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+            gcc
+          ];
+
+          buildInputs = qtModules ++ [
+            pkgs.kdePackages.layer-shell-qt
+            pkgs.pipewire
+          ];
+
+          shellHook = ''
+            export Qt6_DIR="${pkgs.qt6.qtbase}/lib/cmake/Qt6"
+            export CMAKE_PREFIX_PATH="${pkgs.lib.concatStringsSep ":" qtModules}"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
@jswysnemc 您好：

这个 PR 对 mark-shot 添加了 Nix Flake 支持，便于 NixOS 用户集成这个项目

### 修改内容：
- 添加了 flake.nix 和 flake.lock
- 修改了 .gitignore 来排除构建产物
- 修改了 README.md 和 README.zh-CN.md，新增了 NixOS 的安装指南

### 测试内容：
- `nix build` 以及直接在 NixOS 中集成均没有出现异常
- 测试环境：NixOS 26.05，`niri` 26.04

---

Hi @jswysnemc,

This PR adds Nix Flake support to `mark-shot`, making it easier for NixOS users to integrate the project into their configurations.

### Changes:
- Added `flake.nix` and `flake.lock`.
- Updated `.gitignore` to exclude build artifacts.
- Updated `README.md` and `README.zh-CN.md` to include NixOS installation guides.

### Testing:
- Verified both `nix build` and direct NixOS integration locally without any issues.
- Test environment: NixOS 26.05, `niri` 26.04