### PR TITLE
fix: hideOwnWindows toggle — assign to CaptureRequest + read at capture time

### DIFF
--- a/src/capture_session_launcher.cpp
+++ b/src/capture_session_launcher.cpp
@@ -161,6 +161,7 @@ ShotWindow *showCaptureWindow(QScreen *screen,
     request.sourceGeometry = captureGeometry;
     request.allOutputs = allOutputs;
     request.includeCursor = includeCursor;
+    request.hideOwnWindows = hideOwnWindows;
     CaptureResult capture = captureScreenFrame(request);
     if (capture.image.isNull()) {
         if (error) {

--- a/src/capture_session_launcher.cpp
+++ b/src/capture_session_launcher.cpp
@@ -132,6 +132,7 @@ ShotWindow *showCapturedWindow(QScreen *screen,
 /// @param screen 要捕获的显示器。
 /// @param allOutputs 是否捕获全部输出为一张图片。
 /// @param includeCursor 冻结图是否包含鼠标。
+/// @param hideOwnWindows 是否让截屏后端隐藏 mark-shot 自身窗口。
 /// @param useRegularWindow 是否使用普通窗口。
 /// @param fullscreenAnnotation 是否直接进入全屏标注。
 /// @param defaultTools 默认工具配置。
@@ -278,6 +279,7 @@ ShotWindow *showDisplayCaptureTarget(const markshot::display_capture::Target &ta
 /// @param app 应用对象。
 /// @param windows 冻结窗口列表。
 /// @param includeCursor 冻结图是否包含鼠标。
+/// @param hideOwnWindows 是否让截屏后端隐藏 mark-shot 自身窗口。
 /// @param useRegularWindow 是否使用普通窗口。
 /// @param defaultTools 默认工具配置。
 /// @param regionRecordingOptions 区域录制配置，为空时启动普通截图流程。
@@ -404,6 +406,7 @@ void connectCaptureWindowSession(QApplication *app,
 /// @brief 逐个显示器捕获冻结图,但暂不创建覆盖窗口。
 /// @param screens 当前屏幕列表。
 /// @param includeCursor 冻结图是否包含鼠标。
+/// @param hideOwnWindows 是否让截屏后端隐藏 mark-shot 自身窗口。
 /// @param error 输出错误信息。
 /// @return 捕获成功的逐屏冻结帧列表。
 QVector<CapturedScreenFrame> captureScreensIndividually(const QList<QScreen *> &screens,
@@ -478,6 +481,7 @@ QVector<CapturedScreenFrame> captureScreensIndividually(const QList<QScreen *> &
 /// @brief 通过逐屏捕获创建多显示器冻结窗口。
 /// @param screens 当前屏幕列表。
 /// @param includeCursor 冻结图是否包含鼠标。
+/// @param hideOwnWindows 是否让截屏后端隐藏 mark-shot 自身窗口。
 /// @param useRegularWindow 是否使用普通窗口。
 /// @param fullscreenAnnotation 是否直接进入全屏标注。
 /// @param defaultTools 默认工具配置。
@@ -525,6 +529,7 @@ QVector<QPointer<ShotWindow>> showCaptureWindowsFromIndividualFrames(const QList
 /// @brief 使用一次全屏截图为每个屏幕创建冻结窗口。
 /// @param screens 当前屏幕列表。
 /// @param includeCursor 冻结图是否包含鼠标。
+/// @param hideOwnWindows 是否让截屏后端隐藏 mark-shot 自身窗口。
 /// @param useRegularWindow 是否使用普通窗口。
 /// @param fullscreenAnnotation 是否直接进入全屏标注。
 /// @param defaultTools 默认工具配置。

--- a/src/capture_session_launcher.h
+++ b/src/capture_session_launcher.h
@@ -19,6 +19,7 @@ namespace markshot {
 /// @param allOutputs 是否把所有输出捕获为一张虚拟桌面图片。
 /// @param freezeScope 普通区域截图的显示器冻结范围。
 /// @param includeCursor 冻结图是否包含鼠标。
+/// @param hideOwnWindows 是否让截屏后端隐藏 mark-shot 自身窗口。
 /// @param useRegularWindow 是否使用普通窗口替代 layer-shell。
 /// @param fullscreenAnnotation 是否直接进入全屏标注。
 /// @param defaultTools 默认工具配置。

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -299,7 +299,6 @@ int main(int argc, char *argv[])
     const bool allOutputs = parser.isSet(allOutputsOption);
     const markshot::CaptureFreezeScope freezeScope = markshot::configuredCaptureFreezeScope();
     const bool includeCursor = markshot::configuredCaptureIncludeCursor();
-    const bool hideOwnWindows = markshot::configuredHideOwnWindowsDuringCapture();
     const bool useRegularWindow = parser.isSet(xdgWindowOption);
     const bool fullscreenAnnotation = parser.isSet(fullscreenAnnotationOption);
     const markshot::WindowsTrayController::Config trayConfig = markshot::WindowsTrayController::readConfig();
@@ -340,7 +339,6 @@ int main(int argc, char *argv[])
                           &captureActive,
                           freezeScope,
                           includeCursor,
-                          hideOwnWindows,
                           useRegularWindow,
                           defaultTools](bool startFullscreen,
                                         bool requestAllOutputs,
@@ -355,7 +353,7 @@ int main(int argc, char *argv[])
                                          requestAllOutputs,
                                          freezeScope,
                                          includeCursor,
-                                         hideOwnWindows,
+                                         markshot::configuredHideOwnWindowsDuringCapture(),
                                          useRegularWindow,
                                          startFullscreen,
                                          defaultTools,


### PR DESCRIPTION
## Two fixes

### Fix 1: `showCaptureWindow` never assigned `hideOwnWindows` to `CaptureRequest`

`showCaptureWindow()` accepts the `hideOwnWindows` parameter but never copies it into the `CaptureRequest` struct.  As a result the request always carries the struct default value (`true` = "hide caller windows" for KWin) regardless of the user toggle.

The other two multi-screen helpers (`showCaptureWindowsFromIndividualFrames` and `showCaptureWindowsFromSingleFrame`) do assign the field correctly, so this bug **only reproduces on single-monitor setups** (`screenCount == 1` → `shouldFreezeAllScreens` returns false → single-screen path).

- Commit: `cd8ff50`
- Symptom: the "Hide Mark Shot Windows While Capturing" toggle has no effect; own windows are always excluded from the frozen frame on single-monitor setups.

### Fix 2: Read the config at capture time instead of capturing it at startup

The original implementation resolved `configuredHideOwnWindowsDuringCapture()` once in `main()` and captured the result by value in the `launchCapture` lambda.  Changing the toggle requires restarting the tray instance for it to take effect.

Moved the call into `launchCapture` so every capture reads the latest config value.  No restart needed.

- Commit: `051cca9`
- Symptom: toggling the setting required a tray restart to apply.