### PR TITLE
fix(shot-window-layout): add padding to text background width

### DIFF
--- a/src/shot_window_layout.cpp
+++ b/src/shot_window_layout.cpp
@@ -46,7 +46,7 @@ QRectF ShotWindow::textContentRect(const Annotation &annotation, bool widgetCoor
         textHeight = documentSize.height();
     }
 
-    const qreal rectWidth = std::max<qreal>(1.0, std::ceil(textWidth + kTextBackgroundPaddingX * 2.0 * scale));
+    const qreal rectWidth = std::max<qreal>(1.0, std::ceil(textWidth + kTextBackgroundPaddingX * 2.0 * scale) + 5.0);
     const qreal rectHeight = std::max<qreal>(1.0, std::ceil(textHeight + kTextBackgroundPaddingY * 2.0 * scale));
     return QRectF(topLeft, QSizeF(rectWidth, rectHeight));
 }


### PR DESCRIPTION
给文本标注框宽度增加 5px 解决文本标注的换行问题。
备注：文本标注的换行问题，只存在于编辑截图时候，保存后的图片会正常显示，所以下面的截图使用了手机拍摄



效果如下图
修改前：
<img width="1706" height="1279" alt="微信图片_20260715171347_68_114" src="https://github.com/user-attachments/assets/81b9b89b-e771-44dc-b8ea-c7a2c97bf494" />


修改后：
<img width="992" height="589" alt="mark-shot-20260715-170631" src="https://github.com/user-attachments/assets/3161e5aa-951d-4d1e-a6f5-1c2fc4882886" />

下面是 fastfetch 截图
<img width="1747" height="967" alt="image" src="https://github.com/user-attachments/assets/ba8cf98f-7ccd-42e2-84d2-1f2b0b906db3" />

