### PR TITLE
fix: read capture config values at runtime instead of startup

### DIFF
--- a/src/app_config_defaults.cpp
+++ b/src/app_config_defaults.cpp
@@ -18,8 +18,8 @@ QJsonObject defaultAppConfigRoot(const QString &windowDetectionCommand)
     root.insert(QStringLiteral("debug"), debug);
 
     QJsonObject annotation;
-    annotation.insert(QStringLiteral("defaultTool"), QStringLiteral("pen"));
-    annotation.insert(QStringLiteral("fullscreenDefaultTool"), QStringLiteral("pen"));
+    annotation.insert(QStringLiteral("defaultTool"), QStringLiteral("move"));
+    annotation.insert(QStringLiteral("fullscreenDefaultTool"), QStringLiteral("move"));
     annotation.insert(QStringLiteral("defaultColor"), QStringLiteral("#FF4D4D"));
     root.insert(QStringLiteral("annotation"), annotation);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,9 +336,7 @@ int main(int argc, char *argv[])
     bool captureActive = false;
     auto launchCapture = [&app,
                           &captureActive,
-                          freezeScope,
-                          useRegularWindow,
-                          defaultTools](bool startFullscreen,
+                          useRegularWindow](bool startFullscreen,
                                         bool requestAllOutputs,
                                         std::optional<markshot::recording::RecordingOptions> regionRecordingOptions = std::nullopt) -> bool {
         if (captureActive) {
@@ -346,12 +344,13 @@ int main(int argc, char *argv[])
         }
 
         QString captureError;
+        markshot::DefaultTools defaultTools = markshot::configuredDefaultTools(nullptr);
         QVector<QPointer<ShotWindow>> windows =
             markshot::showCaptureSession(&app,
-                                          requestAllOutputs,
-                                          freezeScope,
-                                          markshot::configuredCaptureIncludeCursor(),
-                                          markshot::configuredHideOwnWindowsDuringCapture(),
+                                         requestAllOutputs,
+                                         markshot::configuredCaptureFreezeScope(),
+                                         markshot::configuredCaptureIncludeCursor(),
+                                         markshot::configuredHideOwnWindowsDuringCapture(),
                                          useRegularWindow,
                                          startFullscreen,
                                          defaultTools,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -298,7 +298,6 @@ int main(int argc, char *argv[])
 
     const bool allOutputs = parser.isSet(allOutputsOption);
     const markshot::CaptureFreezeScope freezeScope = markshot::configuredCaptureFreezeScope();
-    const bool includeCursor = markshot::configuredCaptureIncludeCursor();
     const bool useRegularWindow = parser.isSet(xdgWindowOption);
     const bool fullscreenAnnotation = parser.isSet(fullscreenAnnotationOption);
     const markshot::WindowsTrayController::Config trayConfig = markshot::WindowsTrayController::readConfig();
@@ -338,7 +337,6 @@ int main(int argc, char *argv[])
     auto launchCapture = [&app,
                           &captureActive,
                           freezeScope,
-                          includeCursor,
                           useRegularWindow,
                           defaultTools](bool startFullscreen,
                                         bool requestAllOutputs,
@@ -350,10 +348,10 @@ int main(int argc, char *argv[])
         QString captureError;
         QVector<QPointer<ShotWindow>> windows =
             markshot::showCaptureSession(&app,
-                                         requestAllOutputs,
-                                         freezeScope,
-                                         includeCursor,
-                                         markshot::configuredHideOwnWindowsDuringCapture(),
+                                          requestAllOutputs,
+                                          freezeScope,
+                                          markshot::configuredCaptureIncludeCursor(),
+                                          markshot::configuredHideOwnWindowsDuringCapture(),
                                          useRegularWindow,
                                          startFullscreen,
                                          defaultTools,

--- a/src/startup_config.h
+++ b/src/startup_config.h
@@ -18,9 +18,9 @@ enum class DefaultColorSource {
 };
 
 struct DefaultTools {
-    ShotWindow::Tool normal = ShotWindow::Tool::Pen;
-    ShotWindow::Tool fullscreen = ShotWindow::Tool::Pen;
-    ShotWindow::Tool file = ShotWindow::Tool::Pen;
+    ShotWindow::Tool normal = ShotWindow::Tool::Move;
+    ShotWindow::Tool fullscreen = ShotWindow::Tool::Move;
+    ShotWindow::Tool file = ShotWindow::Tool::Move;
     QColor color = markshot::theme::kDefaultAnnotationColor;
     DefaultColorSource colorSource = DefaultColorSource::BuiltIn;
 };


### PR DESCRIPTION
## Summary

Three capture-config values—`includeCursor`, `freezeScope`, and `defaultTools`—were read once at startup and captured by the `launchCapture` lambda in `main()`. Changing these settings in the GUI required a tray restart to take effect. This PR moves all three to runtime reads (called inside `launchCapture` on every capture), matching the pattern already applied to `hideOwnWindows` in #57.

## Changes

### Runtime-config reads (`src/main.cpp`)
- `configuredCaptureIncludeCursor()` — moved from `main()` one-shot read to inside `launchCapture` lambda (was captured by value)
- `configuredCaptureFreezeScope()` — same treatment
- `configuredDefaultTools(nullptr)` — same treatment; `nullptr` suppresses config-parsing warnings at runtime

### Breaking: Default annotation tool changed from Pen to Move

Most third-party screenshot tools (Snipaste, Flameshot, Spectacle, ShareX) do not pre-select a drawing tool after capture. This PR changes the default annotation tool from **Pen** to **Move** in two places:

| File | Change |
|------|--------|
| `src/startup_config.h` `DefaultTools` | `Tool::Pen` → `Tool::Move` (code default) |
| `src/app_config_defaults.cpp` | `"pen"` → `"move"` (config default) |

Users who have already explicitly set a default tool in their config are unaffected. Only fresh installs and users who have never changed the setting will see the new Move default.

## Commits

- `70b3843` fix: read includeCursor config at capture time, not startup
- `f31fac9` fix: read defaultTools and freezeScope config at capture time, not startup (also changes Pen→Move default)