### PR TITLE
fix: Move tool cursor, draggable toolbar grips, UI panel cursor

### DIFF
--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -621,6 +621,7 @@ private:
     bool m_fullscreenAnnotation = false;
     bool m_toolbarDragging = false;
     bool m_toolbarUserPlaced = false;
+    bool m_actionToolbarUserPlaced = false;
     bool m_committingText = false;
     bool m_showSelectionInfo = false;
     bool m_showWheelPreview = false;

--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -469,6 +469,8 @@ private:
     void hideAnnotationPropertyPanels();
     void hideTransientPanels();
     void updateCursor();
+    bool propertyComboPopupVisible() const;
+    bool mouseOverUiWidget() const;
     void clearWheelPreview();
     void updateColorPaletteGeometry(QPoint anchor);
     void updateColorPalettePreview();

--- a/src/shot_window_hit_testing.cpp
+++ b/src/shot_window_hit_testing.cpp
@@ -21,6 +21,11 @@ void ShotWindow::updateCursor()
         return;
     }
 
+    if (propertyComboPopupVisible() || mouseOverUiWidget()) {
+        setCursor(Qt::ArrowCursor);
+        return;
+    }
+
     if (m_tool == Tool::Move && !m_fullscreenAnnotation) {
         switch (m_selectionDrag) {
         case SelectionDrag::MagnifierSource:
@@ -112,6 +117,38 @@ void ShotWindow::updateCursor()
     }
 
     setCursor(m_tool == Tool::Text ? Qt::IBeamCursor : captureCrossCursor());
+}
+
+bool ShotWindow::propertyComboPopupVisible() const
+{
+    return (m_propertyRectangleStyleCombo && m_propertyRectangleStyleCombo->view()->isVisible())
+        || (m_propertyArrowStyleCombo && m_propertyArrowStyleCombo->view()->isVisible())
+        || (m_propertyHighlighterStyleCombo && m_propertyHighlighterStyleCombo->view()->isVisible())
+        || (m_propertyNumberStyleCombo && m_propertyNumberStyleCombo->view()->isVisible());
+}
+
+bool ShotWindow::mouseOverUiWidget() const
+{
+    const QPoint pos = mapFromGlobal(QCursor::pos());
+    for (QWidget *w = childAt(pos); w && w != this; w = w->parentWidget()) {
+        const QString name = w->objectName();
+        if (name == QLatin1String("toolbarGrip")
+            || name == QLatin1String("actionToolbarGrip")) {
+            return false;
+        }
+        if (name == QLatin1String("shotToolbar")
+            || name == QLatin1String("actionToolbar")
+            || name == QLatin1String("annotationPropertyPanel")
+            || name == QLatin1String("propertyColorDialogPanel")
+            || name == QLatin1String("propertyFontPanel")
+            || name == QLatin1String("openWithPanel")
+            || name == QLatin1String("extensionPanel")
+            || name == QLatin1String("colorPalette")
+            || qobject_cast<const QComboBox *>(w)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void ShotWindow::clearWheelPreview()

--- a/src/shot_window_hit_testing.cpp
+++ b/src/shot_window_hit_testing.cpp
@@ -61,7 +61,7 @@ void ShotWindow::updateCursor()
             setCursor(Qt::SizeAllCursor);
             return;
         case SelectionDrag::None:
-            setCursor(captureCrossCursor());
+            setCursor(Qt::ArrowCursor);
             return;
         }
     }

--- a/src/shot_window_input.cpp
+++ b/src/shot_window_input.cpp
@@ -159,7 +159,7 @@ void ShotWindow::mouseMoveEvent(QMouseEvent *event)
             setCursor(Qt::SizeAllCursor);
             break;
         case SelectionDrag::None:
-            setCursor(captureCrossCursor());
+            setCursor(Qt::ArrowCursor);
             break;
         }
         return;

--- a/src/shot_window_input.cpp
+++ b/src/shot_window_input.cpp
@@ -470,6 +470,7 @@ void ShotWindow::mouseReleaseEvent(QMouseEvent *event)
             m_mode = Mode::Editing;
             m_fullscreenAnnotation = false;
             m_toolbarUserPlaced = false;
+            m_actionToolbarUserPlaced = false;
             setTool(defaultEditingTool());
             setFullscreenActionButtonsVisible(false);
             m_toolbar->show();
@@ -539,6 +540,7 @@ void ShotWindow::beginSelection(QPointF imagePoint)
     m_fullscreenAnnotation = false;
     m_toolbarDragging = false;
     m_toolbarUserPlaced = false;
+    m_actionToolbarUserPlaced = false;
     m_selectionDrag = SelectionDrag::None;
     m_selectionBeforeFullscreenAnnotation.reset();
     m_selectionStart = imagePoint;

--- a/src/shot_window_input.cpp
+++ b/src/shot_window_input.cpp
@@ -115,19 +115,6 @@ void ShotWindow::mouseMoveEvent(QMouseEvent *event)
         return;
     }
 
-    if (m_fullscreenAnnotation && m_toolbarDragging) {
-        const QPoint delta = event->pos() - m_toolbarDragStart;
-        QRect toolbarGeometry = m_toolbarBeforeDrag.translated(delta);
-        if (m_toolbar) {
-            m_toolbarUserPlaced = true;
-            m_toolbar->setGeometry(clampedToolbarGeometry(toolbarGeometry));
-        }
-        updateOpenWithPanelGeometry();
-        updateExtensionPanelGeometry();
-        updateAnnotationPropertyPanelGeometry();
-        return;
-    }
-
     if (m_mode == Mode::Editing && m_tool == Tool::Move && !m_fullscreenAnnotation && !m_dragging) {
         const SelectionDrag hoverDrag = selectionDragAt(imagePoint);
         switch (hoverDrag) {
@@ -499,6 +486,7 @@ void ShotWindow::mouseReleaseEvent(QMouseEvent *event)
         m_mode = Mode::Editing;
         m_fullscreenAnnotation = false;
         m_toolbarUserPlaced = false;
+        m_actionToolbarUserPlaced = false;
         setTool(defaultEditingTool());
         setFullscreenActionButtonsVisible(false);
         m_toolbar->show();

--- a/src/shot_window_layout.cpp
+++ b/src/shot_window_layout.cpp
@@ -324,6 +324,14 @@ void ShotWindow::updateActionToolbarGeometry()
     }
 
     m_actionToolbar->adjustSize();
+    if (m_actionToolbarUserPlaced) {
+        const QSize toolbarSize = m_actionToolbar->sizeHint();
+        QRect toolbarGeometry = m_actionToolbar->geometry();
+        toolbarGeometry.setSize(toolbarSize);
+        m_actionToolbar->setGeometry(clampedToolbarGeometry(toolbarGeometry));
+        return;
+    }
+
     const QRectF selection = imageRectToWidget(normalizedSelection());
     const QSize toolbarSize = m_actionToolbar->sizeHint();
     const QRect selectionRect = selection.toAlignedRect();

--- a/src/shot_window_layout.cpp
+++ b/src/shot_window_layout.cpp
@@ -287,7 +287,7 @@ void ShotWindow::updateToolbarGeometry()
     }
 
     m_toolbar->adjustSize();
-    if (m_fullscreenAnnotation && m_toolbarUserPlaced) {
+    if (m_toolbarUserPlaced) {
         const QSize toolbarSize = m_toolbar->sizeHint();
         QRect toolbarGeometry = m_toolbar->geometry();
         toolbarGeometry.setSize(toolbarSize);

--- a/src/shot_window_modes.cpp
+++ b/src/shot_window_modes.cpp
@@ -445,8 +445,12 @@ bool ShotWindow::eventFilter(QObject *watched, QEvent *event)
                 return false;
             }
             const QPoint delta = eventWidget->mapTo(this, mouseEvent->pos()) - m_toolbarDragStart;
-            m_toolbarUserPlaced = true;
-            m_actionToolbarUserPlaced = true;
+            if (targetToolbar == m_toolbar) {
+                m_toolbarUserPlaced = true;
+            }
+            if (targetToolbar == m_actionToolbar) {
+                m_actionToolbarUserPlaced = true;
+            }
             targetToolbar->setGeometry(clampedToolbarGeometry(m_toolbarBeforeDrag.translated(delta)));
             updateOpenWithPanelGeometry();
             updateExtensionPanelGeometry();

--- a/src/shot_window_modes.cpp
+++ b/src/shot_window_modes.cpp
@@ -51,6 +51,7 @@ void ShotWindow::enterFullscreenAnnotation(bool resetAnnotations)
     updateMinimumImageWindowSize();
     m_toolbarDragging = false;
     m_toolbarUserPlaced = false;
+    m_actionToolbarUserPlaced = false;
     m_selection = QRectF(QPointF(0, 0), QSizeF(m_frozenFrame.size()));
     if (resetAnnotations) {
         m_annotations.clear();
@@ -100,6 +101,7 @@ void ShotWindow::leaveFullscreenAnnotation()
     m_dragging = false;
     m_toolbarDragging = false;
     m_toolbarUserPlaced = false;
+    m_actionToolbarUserPlaced = false;
     m_fullscreenAnnotation = false;
     m_toolbarVerticalLayout = false;
     applyToolbarLayout();
@@ -158,6 +160,7 @@ void ShotWindow::toggleToolbarLayout()
 {
     m_toolbarVerticalLayout = !m_toolbarVerticalLayout;
     m_toolbarUserPlaced = false;
+    m_actionToolbarUserPlaced = false;
     applyToolbarLayout();
     updateToolbarGeometry();
     updateOpenWithPanelGeometry();
@@ -418,7 +421,9 @@ bool ShotWindow::eventFilter(QObject *watched, QEvent *event)
     const bool isFullscreenMoveButton = m_fullscreenAnnotation
         && watched->property("action").toString() == markshot::ui::actionName(Action::ToolMove);
     const bool isToolbarGrip = watched->objectName() == QStringLiteral("toolbarGrip");
-    if (isFullscreenMoveButton || isToolbarGrip) {
+    const bool isActionToolbarGrip = watched->objectName() == QStringLiteral("actionToolbarGrip");
+    if (isFullscreenMoveButton || isToolbarGrip || isActionToolbarGrip) {
+        QWidget *targetToolbar = isActionToolbarGrip ? m_actionToolbar : m_toolbar;
         if (event->type() == QEvent::MouseButtonPress) {
             auto *mouseEvent = static_cast<QMouseEvent *>(event);
             if (mouseEvent->button() == Qt::LeftButton) {
@@ -429,7 +434,7 @@ bool ShotWindow::eventFilter(QObject *watched, QEvent *event)
                 m_dragging = true;
                 m_toolbarDragging = true;
                 m_toolbarDragStart = eventWidget->mapTo(this, mouseEvent->pos());
-                m_toolbarBeforeDrag = m_toolbar->geometry();
+                m_toolbarBeforeDrag = targetToolbar->geometry();
                 setCursor(Qt::SizeAllCursor);
                 return true;
             }
@@ -441,7 +446,8 @@ bool ShotWindow::eventFilter(QObject *watched, QEvent *event)
             }
             const QPoint delta = eventWidget->mapTo(this, mouseEvent->pos()) - m_toolbarDragStart;
             m_toolbarUserPlaced = true;
-            m_toolbar->setGeometry(clampedToolbarGeometry(m_toolbarBeforeDrag.translated(delta)));
+            m_actionToolbarUserPlaced = true;
+            targetToolbar->setGeometry(clampedToolbarGeometry(m_toolbarBeforeDrag.translated(delta)));
             updateOpenWithPanelGeometry();
             updateExtensionPanelGeometry();
             updateAnnotationPropertyPanelGeometry();

--- a/src/shot_window_modes.cpp
+++ b/src/shot_window_modes.cpp
@@ -417,7 +417,8 @@ bool ShotWindow::eventFilter(QObject *watched, QEvent *event)
 
     const bool isFullscreenMoveButton = m_fullscreenAnnotation
         && watched->property("action").toString() == markshot::ui::actionName(Action::ToolMove);
-    if (isFullscreenMoveButton) {
+    const bool isToolbarGrip = watched->objectName() == QStringLiteral("toolbarGrip");
+    if (isFullscreenMoveButton || isToolbarGrip) {
         if (event->type() == QEvent::MouseButtonPress) {
             auto *mouseEvent = static_cast<QMouseEvent *>(event);
             if (mouseEvent->button() == Qt::LeftButton) {

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -527,6 +527,24 @@ void ShotWindow::initializeActionToolbar()
     auto *actionLayout = new QVBoxLayout(m_actionToolbar);
     actionLayout->setContentsMargins(4, 4, 4, 4);
     actionLayout->setSpacing(2);
+
+    QWidget *actionGrip = new QWidget(m_actionToolbar);
+    actionGrip->setObjectName(QStringLiteral("actionToolbarGrip"));
+    actionGrip->setFixedHeight(10);
+    actionGrip->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    actionGrip->setCursor(Qt::SizeAllCursor);
+    actionGrip->setStyleSheet(
+        QStringLiteral("QWidget#actionToolbarGrip {"
+                       "  background-color: rgba(148,163,184,60);"
+                       "  border-radius: 2px;"
+                       "  margin: 0px 2px;"
+                       "}"
+                       "QWidget#actionToolbarGrip:hover {"
+                       "  background-color: rgba(148,163,184,120);"
+                       "}"));
+    actionGrip->installEventFilter(this);
+    actionLayout->addWidget(actionGrip);
+
     for (QPushButton *button : {
              addToolbarButton(Action::ToggleCaptureScope, shortcutText(Action::ToggleCaptureScope), m_actionToolbar),
              addToolbarButton(Action::OpenWith, shortcutText(Action::OpenWith, QStringLiteral("Open")), m_actionToolbar),

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -411,6 +411,7 @@ void ShotWindow::initializeToolbar()
 {
     m_toolbar = new QWidget(this);
     m_toolbar->setObjectName(QStringLiteral("shotToolbar"));
+    m_toolbar->setCursor(Qt::ArrowCursor);
     m_toolbar->setStyleSheet(
         markshot::theme::panelStyleSheet(m_toolbarAppearance.toolbarButtonSize, m_toolbarAppearance.fontSize));
     m_toolbar->installEventFilter(this);
@@ -514,6 +515,7 @@ void ShotWindow::initializeActionToolbar()
 {
     m_actionToolbar = new QWidget(this);
     m_actionToolbar->setObjectName(QStringLiteral("actionToolbar"));
+    m_actionToolbar->setCursor(Qt::ArrowCursor);
     const int actionButtonSize = m_toolbarAppearance.actionToolbarButtonSize;
     m_actionToolbar->setStyleSheet(m_toolbar->styleSheet()
         + QStringLiteral(

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -143,6 +143,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
 
     m_annotationPropertyPanel = new QWidget(this);
     m_annotationPropertyPanel->setObjectName(QStringLiteral("annotationPropertyPanel"));
+    m_annotationPropertyPanel->setCursor(Qt::ArrowCursor);
     m_annotationPropertyPanel->setStyleSheet(m_toolbar->styleSheet());
     const qreal propertyScale = std::max<qreal>(1.0, m_toolbarAppearance.fontSize / 11.0);
     const int propertyMarginX = std::max(8, qRound(8 * propertyScale));
@@ -247,6 +248,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
     propertyLayout->addWidget(m_propertyRadiusSlider);
     // 矩形风格切换:描边/高亮/反色,仅在 Tool::Rectangle 选中或激活时显示
     m_propertyRectangleStyleCombo = new QComboBox(m_annotationPropertyPanel);
+    m_propertyRectangleStyleCombo->setCursor(Qt::ArrowCursor);
     m_propertyRectangleStyleCombo->setFocusPolicy(Qt::NoFocus);
     m_propertyRectangleStyleCombo->addItem(MS_TR("Stroke"), static_cast<int>(RectangleStyle::Stroke));
     m_propertyRectangleStyleCombo->addItem(MS_TR("Highlight"), static_cast<int>(RectangleStyle::Highlight));
@@ -262,6 +264,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
     });
     propertyLayout->addWidget(m_propertyRectangleStyleCombo);
     m_propertyArrowStyleCombo = new QComboBox(m_annotationPropertyPanel);
+    m_propertyArrowStyleCombo->setCursor(Qt::ArrowCursor);
     m_propertyArrowStyleCombo->setFocusPolicy(Qt::NoFocus);
     m_propertyArrowStyleCombo->addItem(MS_TR("Fletched"), static_cast<int>(ArrowStyle::Fletched));
     m_propertyArrowStyleCombo->addItem(MS_TR("KDE"), static_cast<int>(ArrowStyle::Kde));
@@ -277,6 +280,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
     });
     propertyLayout->addWidget(m_propertyArrowStyleCombo);
     m_propertyHighlighterStyleCombo = new QComboBox(m_annotationPropertyPanel);
+    m_propertyHighlighterStyleCombo->setCursor(Qt::ArrowCursor);
     m_propertyHighlighterStyleCombo->setFocusPolicy(Qt::NoFocus);
     m_propertyHighlighterStyleCombo->addItem(MS_TR("Pen"), static_cast<int>(HighlighterStyle::Freehand));
     m_propertyHighlighterStyleCombo->addItem(MS_TR("Line"), static_cast<int>(HighlighterStyle::StraightLine));
@@ -291,6 +295,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
     });
     propertyLayout->addWidget(m_propertyHighlighterStyleCombo);
     m_propertyNumberStyleCombo = new QComboBox(m_annotationPropertyPanel);
+    m_propertyNumberStyleCombo->setCursor(Qt::ArrowCursor);
     m_propertyNumberStyleCombo->setFocusPolicy(Qt::NoFocus);
     m_propertyNumberStyleCombo->addItem(MS_TR("1, 2, 3"), static_cast<int>(NumberStyle::Arabic));
     m_propertyNumberStyleCombo->addItem(MS_TR("A, B, C"), static_cast<int>(NumberStyle::UpperAlpha));
@@ -360,6 +365,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
 
     m_propertyColorDialogPanel = new QWidget(this);
     m_propertyColorDialogPanel->setObjectName(QStringLiteral("propertyColorDialogPanel"));
+    m_propertyColorDialogPanel->setCursor(Qt::ArrowCursor);
     m_propertyColorDialogPanel->setStyleSheet(markshot::theme::propertyColorDialogPanelStyleSheet());
     auto *propertyColorLayout = new QVBoxLayout(m_propertyColorDialogPanel);
     propertyColorLayout->setContentsMargins(8, 8, 8, 8);
@@ -373,6 +379,7 @@ ShotWindow::ShotWindow(QImage frozenFrame,
 
     m_propertyFontPanel = new QWidget(this);
     m_propertyFontPanel->setObjectName(QStringLiteral("propertyFontPanel"));
+    m_propertyFontPanel->setCursor(Qt::ArrowCursor);
     m_propertyFontPanel->setStyleSheet(markshot::theme::openWithPanelStyleSheet());
     auto *fontPanelLayout = new QVBoxLayout(m_propertyFontPanel);
     fontPanelLayout->setContentsMargins(6, 6, 6, 6);
@@ -571,6 +578,7 @@ void ShotWindow::initializeTransientPanels()
 {
     m_openWithPanel = new QWidget(this);
     m_openWithPanel->setObjectName(QStringLiteral("openWithPanel"));
+    m_openWithPanel->setCursor(Qt::ArrowCursor);
     m_openWithPanel->setStyleSheet(markshot::theme::openWithPanelStyleSheet());
     auto *openLayout = new QVBoxLayout(m_openWithPanel);
     openLayout->setContentsMargins(8, 8, 8, 8);
@@ -579,6 +587,7 @@ void ShotWindow::initializeTransientPanels()
 
     m_extensionPanel = new QWidget(this);
     m_extensionPanel->setObjectName(QStringLiteral("extensionPanel"));
+    m_extensionPanel->setCursor(Qt::ArrowCursor);
     m_extensionPanel->setStyleSheet(markshot::theme::openWithPanelStyleSheet());
     auto *extensionLayout = new QVBoxLayout(m_extensionPanel);
     extensionLayout->setContentsMargins(8, 8, 8, 8);
@@ -587,6 +596,7 @@ void ShotWindow::initializeTransientPanels()
 
     m_colorPalette = new QWidget(this);
     m_colorPalette->setObjectName(QStringLiteral("colorPalette"));
+    m_colorPalette->setCursor(Qt::ArrowCursor);
     m_colorPalette->setStyleSheet(markshot::theme::colorPaletteStyleSheet());
     for (const QColor &color : markshot::theme::paletteColors()) {
         auto *button = new QPushButton(m_colorPalette);

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -419,6 +419,23 @@ void ShotWindow::initializeToolbar()
     m_toolbarLayout->setContentsMargins(6, 6, 6, 6);
     m_toolbarLayout->setSpacing(3);
 
+    QWidget *toolbarGrip = new QWidget(m_toolbar);
+    toolbarGrip->setObjectName(QStringLiteral("toolbarGrip"));
+    toolbarGrip->setFixedWidth(10);
+    toolbarGrip->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    toolbarGrip->setCursor(Qt::SizeAllCursor);
+    toolbarGrip->setStyleSheet(
+        QStringLiteral("QWidget#toolbarGrip {"
+                       "  background-color: rgba(148,163,184,60);"
+                       "  border-radius: 2px;"
+                       "  margin: 2px 0px;"
+                       "}"
+                       "QWidget#toolbarGrip:hover {"
+                       "  background-color: rgba(148,163,184,120);"
+                       "}"));
+    toolbarGrip->installEventFilter(this);
+    m_toolbarLayout->addWidget(toolbarGrip);
+
     m_toolbarLayout->addWidget(addToolbarButton(Action::ToolMove, shortcutText(Tool::Move)));
     m_toolbarLayout->addWidget(addToolbarButton(Action::ToolSelect, shortcutText(Tool::Select)));
     m_toolbarLayout->addWidget(addToolbarButton(Action::ToolPen, shortcutText(Tool::Pen)));


### PR DESCRIPTION
## Summary

Five fixes targeting the annotation editing experience after a region screenshot:

---

### 1. Move tool cursor shows crosshair instead of arrow outside the selection

When the **Move** tool was selected after capturing a region, the cursor inside the selection box correctly showed resize handles, but **outside the box it showed a crosshair** (`captureCrossCursor()`) — the same as Pen/Line drawing tools. The **Select** tool correctly shows `Qt::ArrowCursor` outside the box.

**Fix:** `shot_window_hit_testing.cpp` (`updateCursor`) and `shot_window_input.cpp` (`mouseMoveEvent`).

---

### 2. Neither toolbar can be moved after region capture

After a region screenshot in normal editing mode, the annotation toolbar (bottom) and action toolbar (right-side: Copy/Save/Cancel) were auto-positioned and could not be dragged by the user.

**Fix:**
- Added a small **drag grip** widget (10px, semi-transparent, highlights on hover with `SizeAllCursor`) to each toolbar — at the left edge of the main toolbar, and at the top of the action toolbar
- Extended `eventFilter()` to detect both grips (`toolbarGrip` / `actionToolbarGrip`) and drag the correct toolbar widget
- `updateActionToolbarGeometry()` now respects a new `m_actionToolbarUserPlaced` flag
- `m_toolbarUserPlaced` and `m_actionToolbarUserPlaced` are gated by which toolbar is actually being dragged
- Removed the redundant `mouseMoveEvent` fullscreen toolbar-drag block (coordinate-space mismatch with eventFilter)
- Both flags are reset at all sites where toolbar auto-positioning should take over

---

### 3. Drawing-tool crosshair cursor over all UI panels

When a drawing tool (Pen, Line, Rectangle, Arrow, Text, Number, Mosaic, Magnifier, Highlighter, Laser, etc.) was selected, the crosshair cursor persisted over **all UI panels** — toolbar buttons, property panels, color picker, font list, Open With panel, extensions panel, and the color palette.

**Fix:** Set `Qt::ArrowCursor` on all overlay widget containers at creation time. Child widgets inherit unless they set their own cursor (the drag grips use `SizeAllCursor`). Panels covered:

| Widget | Area |
|--------|------|
| `m_toolbar` | Main annotation toolbar (all tool buttons + action buttons) |
| `m_actionToolbar` | Right-side action toolbar (Copy, Save, Cancel, etc.) |
| `m_annotationPropertyPanel` | Width/opacity/color/font property bar |
| `m_propertyColorDialogPanel` | Color picker dialog |
| `m_propertyFontPanel` | Font family list (scroll area) |
| `m_openWithPanel` | "Open With" application list |
| `m_extensionPanel` | Extensions list |
| `m_colorPalette` | Quick-color palette |

---

### 4. Combo box popup cursor crosshair

When a drawing tool was active and the user opened a property combo box (highlighter style, rectangle fill, arrow style, number badge), the popup was open but the cursor outside (and sometimes inside) the popup reverted to crosshair.

**Fix:** `updateCursor()` now runs two helper checks at the top:
- `mouseOverUiWidget()` — walks `childAt()` parent chain from the mouse position; returns true if any ancestor is a known UI widget (toolbar, panels, QComboBox). Grip widgets are excluded so their `SizeAllCursor` is preserved.
- `propertyComboPopupVisible()` — returns true if any of the four property combo box popup views is currently visible.

When either check is true, `updateCursor()` immediately sets `Qt::ArrowCursor`, overriding all tool-specific cursors. This replaces the previous fragile per-widget `setCursor` and combo-popup eventFilter approach.

---

### 5. Property panel combo box cursor

**Fix:** Set `Qt::ArrowCursor` on the four `QComboBox` widgets in the property panel (`m_propertyRectangleStyleCombo`, `m_propertyArrowStyleCombo`, `m_propertyHighlighterStyleCombo`, `m_propertyNumberStyleCombo`).

---

### Files Changed

| File | Change |
|------|--------|
| `src/shot_window.h` | Add `m_actionToolbarUserPlaced` member + 2 method declarations |
| `src/shot_window_hit_testing.cpp` | Move tool cursor fix; `mouseOverUiWidget()` + `propertyComboPopupVisible()` helpers; `updateCursor()` early-return for UI widgets |
| `src/shot_window_input.cpp` | Move tool cursor fix; `m_actionToolbarUserPlaced` resets; remove redundant toolbar-drag block |
| `src/shot_window_modes.cpp` | Grip detection in `eventFilter`; target-toolbar-aware flag gating; `m_actionToolbarUserPlaced` resets |
| `src/shot_window_setup.cpp` | Grip widgets for both toolbars; `Qt::ArrowCursor` on all overlay panels; cursor on 4 QComboBoxes |
| `src/shot_window_layout.cpp` | `updateActionToolbarGeometry` respects `m_actionToolbarUserPlaced` |

### Commits

- `7e7e6bb` refactor: unify cursor-in-UI-widget detection in updateCursor()
- `9ca1844` fix: Arrow cursor on all overlay panels and property dialogs
- `b2d1010` fix: show Arrow cursor when hovering over toolbar widgets
- `54328ec` fix: add drag grip to action toolbar (right-side action buttons)
- `eb73080` fix: Arrow cursor outside selection for Move tool + draggable toolbar grip
