### PR TITLE
feat(cli): add headless capture mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ packaging/aur/mark-shot-*/
 .doc/
 __pycache__/
 *.py[cod]
+
+# 内部进度台账，不纳入版本控制（避免暴露给用户/上游）
+docs/ITERATION-LOG.md

--- a/README.md
+++ b/README.md
@@ -184,15 +184,29 @@ mark-shot --capture-to /tmp/region.png --region 0,0,1280,720
 # Capture a specific monitor by name, with the mouse cursor included
 mark-shot --capture-to /tmp/window.png --display DP-1 --include-cursor
 
+# Capture several monitors at once (repeat --display; one PNG per monitor)
+mark-shot --capture-to /tmp/shots/ --display DP-1 --display DP-2
+
 # Print the available outputs as JSON and exit
 mark-shot --list-displays
 ```
 
-The JSON output of `--capture-to` looks like:
+The JSON output of a single-display `--capture-to` looks like:
 
 ```json
 {"path":"/tmp/shot.png","width":2560,"height":1440,"output":"DP-1","error":null}
 ```
+
+When more than one `--display` is requested the output becomes an array of
+captures, one per monitor:
+
+```json
+{"captures":[{"path":"/tmp/shots/mark-shot-DP-1-20260801-000000.png","width":2560,"height":1440,"output":"DP-1","error":null},
+             {"path":"/tmp/shots/mark-shot-DP-2-20260801-000000.png","width":1920,"height":1080,"output":"DP-2","error":null}]}
+```
+
+Each selected monitor is captured with its own source geometry, so portal-based
+backends return exactly that display instead of the whole virtual desktop.
 
 Headless capture reuses the same capture backends as the interactive UI
 (QScreen, xdg-desktop-portal, PipeWire, grim, KWin/GNOME helpers, and Windows
@@ -223,7 +237,7 @@ argument.
 | `--debug-log <path>` | Writes debug logs to the specified path and enables debug logging unless `--no-debug` is also set. |
 | `--capture-to <path>` | Headless capture: writes a PNG to the given file or directory without opening the UI. Prints a JSON summary to stdout. |
 | `--region <x,y,w,h>` | With `--capture-to`: capture only the logical screen region. |
-| `--display <name>` | With `--capture-to`: capture a specific output by monitor name. |
+| `--display <name>` | With `--capture-to`: capture a specific output by monitor name. May be repeated to capture several monitors at once (one PNG each). |
 | `--include-cursor` | With `--capture-to`: draw the mouse cursor into the captured frame. |
 | `--output-name <name>` | With `--capture-to`: base file name (without extension) used when the capture path is a directory. |
 | `--list-displays` | Prints the available outputs as JSON and exits. |
@@ -343,6 +357,22 @@ For other distributions (such as Debian, Ubuntu, or Fedora), download the compil
   ```
 
 The official `.deb` package is built on a Debian 12 compatibility baseline. It intentionally avoids linking the optional LayerShellQt plugin so that Deepin and other Debian-derived systems with Qt 6.8-era packages can install it without Ubuntu `t64` or newer GCC runtime dependencies.
+
+> **Ubuntu 26.04 LTS**: Mark Shot is verified and supported on Ubuntu 26.04 LTS
+> ("Resolute"). Building from source on Ubuntu 26.04 uses the distro Qt 6.10
+> packages directly (no `aqtinstall` step needed):
+>
+> ```bash
+> sudo apt install build-essential cmake ninja-build pkg-config \
+>   qt6-base-dev qt6-wayland libpipewire-0.3-dev libxcb-cursor0 \
+>   xdg-desktop-portal pipewire xclip
+> cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+> cmake --build build
+> ```
+>
+> Headless capture (`--capture-to`), multi-display capture (repeatable
+> `--display`), and the local MCP server all run on Ubuntu 26.04 under both
+> Wayland (GNOME) and X11 sessions.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,41 @@ mark-shot --pin-image path/to/image.png
 mark-shot --xdg-window
 ```
 
+#### Headless (non-interactive) capture
+
+Scripts, CI jobs, and other programs can capture the screen without opening
+the annotation UI. The captured frame is written to a PNG and a compact JSON
+summary is printed to stdout:
+
+```bash
+# Capture the primary screen to a PNG
+mark-shot --capture-to /tmp/shot.png
+
+# Capture into a directory (a timestamped file name is generated)
+mark-shot --capture-to /tmp/shots/
+
+# Capture a logical screen region (x,y,width,height)
+mark-shot --capture-to /tmp/region.png --region 0,0,1280,720
+
+# Capture a specific monitor by name, with the mouse cursor included
+mark-shot --capture-to /tmp/window.png --display DP-1 --include-cursor
+
+# Print the available outputs as JSON and exit
+mark-shot --list-displays
+```
+
+The JSON output of `--capture-to` looks like:
+
+```json
+{"path":"/tmp/shot.png","width":2560,"height":1440,"output":"DP-1","error":null}
+```
+
+Headless capture reuses the same capture backends as the interactive UI
+(QScreen, xdg-desktop-portal, PipeWire, grim, KWin/GNOME helpers, and Windows
+Graphics Capture), so image quality and region handling are identical. All
+headless options are mutually exclusive with the positional image-file
+argument.
+
 ### CLI Arguments
 
 | Option | Description |
@@ -186,6 +221,12 @@ mark-shot --xdg-window
 | `--debug` | Enables debug logging for this run. |
 | `--no-debug` | Disables debug logging for this run, overriding config and environment variables. |
 | `--debug-log <path>` | Writes debug logs to the specified path and enables debug logging unless `--no-debug` is also set. |
+| `--capture-to <path>` | Headless capture: writes a PNG to the given file or directory without opening the UI. Prints a JSON summary to stdout. |
+| `--region <x,y,w,h>` | With `--capture-to`: capture only the logical screen region. |
+| `--display <name>` | With `--capture-to`: capture a specific output by monitor name. |
+| `--include-cursor` | With `--capture-to`: draw the mouse cursor into the captured frame. |
+| `--output-name <name>` | With `--capture-to`: base file name (without extension) used when the capture path is a directory. |
+| `--list-displays` | Prints the available outputs as JSON and exits. |
 
 ### Compositor / Desktop Hotkey Integration
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,15 +181,28 @@ mark-shot --capture-to /tmp/region.png --region 0,0,1280,720
 # 按显示器名称捕获指定屏幕，并包含鼠标指针
 mark-shot --capture-to /tmp/window.png --display DP-1 --include-cursor
 
+# 同时捕获多个显示器（可重复 --display，每个显示器一张 PNG）
+mark-shot --capture-to /tmp/shots/ --display DP-1 --display DP-2
+
 # 以 JSON 输出当前所有显示器信息并退出
 mark-shot --list-displays
 ```
 
-`--capture-to` 的 JSON 输出示例：
+单显示器 `--capture-to` 的 JSON 输出示例：
 
 ```json
 {"path":"/tmp/shot.png","width":2560,"height":1440,"output":"DP-1","error":null}
 ```
+
+当指定多个 `--display` 时，输出变为每屏一个捕获的数组：
+
+```json
+{"captures":[{"path":"/tmp/shots/mark-shot-DP-1-20260801-000000.png","width":2560,"height":1440,"output":"DP-1","error":null},
+             {"path":"/tmp/shots/mark-shot-DP-2-20260801-000000.png","width":1920,"height":1080,"output":"DP-2","error":null}]}
+```
+
+每个选中的显示器使用各自的源几何进行捕获，因此 portal 类后端会精确返回
+该显示器而不是整个虚拟桌面。
 
 无界面截图复用与交互界面相同的全部捕获后端（QScreen、
 xdg-desktop-portal、PipeWire、grim、KWin/GNOME 辅助、Windows Graphics Capture），
@@ -218,7 +231,7 @@ xdg-desktop-portal、PipeWire、grim、KWin/GNOME 辅助、Windows Graphics Capt
 | `--debug-log <path>` | 将调试日志写入指定路径；除非同时设置 `--no-debug`，否则会启用调试日志。 |
 | `--capture-to <path>` | 无界面截图：将 PNG 写入指定文件或目录，不打开界面；向标准输出打印 JSON 摘要。 |
 | `--region <x,y,w,h>` | 配合 `--capture-to` 使用：只捕获指定逻辑屏幕区域。 |
-| `--display <name>` | 配合 `--capture-to` 使用：按显示器名称捕获指定输出屏幕。 |
+| `--display <name>` | 配合 `--capture-to` 使用：按显示器名称捕获指定输出屏幕。可重复指定以一次捕获多个显示器（每屏一张 PNG）。 |
 | `--include-cursor` | 配合 `--capture-to` 使用：将鼠标指针绘制进捕获帧。 |
 | `--output-name <name>` | 配合 `--capture-to` 使用：当捕获路径为目录时使用的基准文件名（不含扩展名）。 |
 | `--list-displays` | 以 JSON 输出当前所有显示器信息并退出。 |
@@ -337,6 +350,21 @@ home.packages = with pkgs; [
   ```bash
   sudo dnf install ./mark-shot-<version>-1.x86_64.rpm
   ```
+
+> **Ubuntu 26.04 LTS**：Mark Shot 已在 Ubuntu 26.04 LTS（Resolute）上验证并支持。
+> 在 Ubuntu 26.04 上从源码构建可直接使用发行版自带的 Qt 6.10 软件包
+> （无需 `aqtinstall` 步骤）：
+>
+> ```bash
+> sudo apt install build-essential cmake ninja-build pkg-config \
+>   qt6-base-dev qt6-wayland libpipewire-0.3-dev libxcb-cursor0 \
+>   xdg-desktop-portal pipewire xclip
+> cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+> cmake --build build
+> ```
+>
+> 无头截图（`--capture-to`）、多显示器截图（可重复的 `--display`）以及本地
+> MCP 服务均可在 Ubuntu 26.04 的 Wayland（GNOME）与 X11 会话下运行。
 
 ### 系统依赖
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,6 +163,38 @@ mark-shot --pin-image path/to/image.png
 mark-shot --xdg-window
 ```
 
+#### 无界面（非交互）截图
+
+脚本、CI 自动化或其它程序可调用 `mark-shot` 完成截图而无需打开标注界面。
+捕获的帧会写入 PNG，并向标准输出打印一行紧凑的 JSON 摘要：
+
+```bash
+# 捕获主屏并写入 PNG
+mark-shot --capture-to /tmp/shot.png
+
+# 写入目录（自动生成带时间戳的文件名）
+mark-shot --capture-to /tmp/shots/
+
+# 捕获逻辑屏幕区域（x,y,宽度,高度）
+mark-shot --capture-to /tmp/region.png --region 0,0,1280,720
+
+# 按显示器名称捕获指定屏幕，并包含鼠标指针
+mark-shot --capture-to /tmp/window.png --display DP-1 --include-cursor
+
+# 以 JSON 输出当前所有显示器信息并退出
+mark-shot --list-displays
+```
+
+`--capture-to` 的 JSON 输出示例：
+
+```json
+{"path":"/tmp/shot.png","width":2560,"height":1440,"output":"DP-1","error":null}
+```
+
+无界面截图复用与交互界面相同的全部捕获后端（QScreen、
+xdg-desktop-portal、PipeWire、grim、KWin/GNOME 辅助、Windows Graphics Capture），
+因此图像质量与区域裁剪行为完全一致。所有无界面参数与位置图片文件参数互斥。
+
 ### CLI 参数说明
 
 | 参数选项 | 功能描述 |
@@ -184,6 +216,12 @@ mark-shot --xdg-window
 | `--debug` | 为本次运行启用调试日志。 |
 | `--no-debug` | 为本次运行禁用调试日志，并覆盖配置文件和环境变量。 |
 | `--debug-log <path>` | 将调试日志写入指定路径；除非同时设置 `--no-debug`，否则会启用调试日志。 |
+| `--capture-to <path>` | 无界面截图：将 PNG 写入指定文件或目录，不打开界面；向标准输出打印 JSON 摘要。 |
+| `--region <x,y,w,h>` | 配合 `--capture-to` 使用：只捕获指定逻辑屏幕区域。 |
+| `--display <name>` | 配合 `--capture-to` 使用：按显示器名称捕获指定输出屏幕。 |
+| `--include-cursor` | 配合 `--capture-to` 使用：将鼠标指针绘制进捕获帧。 |
+| `--output-name <name>` | 配合 `--capture-to` 使用：当捕获路径为目录时使用的基准文件名（不含扩展名）。 |
+| `--list-displays` | 以 JSON 输出当前所有显示器信息并退出。 |
 
 ### 快捷键绑定
 

--- a/cmake/cli_sources.cmake
+++ b/cmake/cli_sources.cmake
@@ -1,4 +1,6 @@
 set(MARK_SHOT_CLI_SOURCES
+    src/cli/headless_capture.cpp
+    src/cli/headless_capture.h
     src/cli/recording_cli.cpp
     src/cli/recording_cli.h
 )

--- a/src/cli/headless_capture.cpp
+++ b/src/cli/headless_capture.cpp
@@ -1,0 +1,218 @@
+#include "cli/headless_capture.h"
+
+#include "screen_capture.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFileInfo>
+#include <QGuiApplication>
+#include <QImageWriter>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QScreen>
+#include <QTextStream>
+
+#include <optional>
+
+namespace markshot::cli {
+namespace {
+
+// Parses "x,y,w,h" into a QRect. Returns nullopt when malformed or empty.
+std::optional<QRect> parseRegion(const QString &value)
+{
+    const QStringList parts = value.split(QLatin1Char(','));
+    if (parts.size() != 4) {
+        return std::nullopt;
+    }
+    bool xOk = false;
+    bool yOk = false;
+    bool wOk = false;
+    bool hOk = false;
+    const int x = parts.at(0).trimmed().toInt(&xOk);
+    const int y = parts.at(1).trimmed().toInt(&yOk);
+    const int w = parts.at(2).trimmed().toInt(&wOk);
+    const int h = parts.at(3).trimmed().toInt(&hOk);
+    if (!xOk || !yOk || !wOk || !hOk || w <= 0 || h <= 0) {
+        return std::nullopt;
+    }
+    return QRect(x, y, w, h);
+}
+
+QByteArray displaysJson()
+{
+    QJsonArray displays;
+    const QList<QScreen *> screens = QGuiApplication::screens();
+    for (QScreen *screen : screens) {
+        if (!screen) {
+            continue;
+        }
+        QJsonObject entry;
+        entry.insert(QStringLiteral("name"), screen->name());
+        const QRect geometry = screen->geometry();
+        entry.insert(QStringLiteral("x"), geometry.x());
+        entry.insert(QStringLiteral("y"), geometry.y());
+        entry.insert(QStringLiteral("width"), geometry.width());
+        entry.insert(QStringLiteral("height"), geometry.height());
+        entry.insert(QStringLiteral("dpr"), screen->devicePixelRatio());
+        entry.insert(QStringLiteral("primary"), screen == QGuiApplication::primaryScreen());
+        displays.append(entry);
+    }
+    QJsonObject root;
+    root.insert(QStringLiteral("displays"), displays);
+    return QJsonDocument(root).toJson(QJsonDocument::Compact);
+}
+
+// Resolves the final output path. When the user passes a directory, a
+// timestamped file name is generated inside it.
+QString resolveOutputPath(const QString &captureTo, const QString &outputName, QString *error)
+{
+    QFileInfo info(captureTo);
+    if (info.isDir()) {
+        const QString stamp =
+            QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss"));
+        QString fileName = QStringLiteral("mark-shot-%1.png").arg(stamp);
+        if (!outputName.isEmpty()) {
+            fileName = QStringLiteral("mark-shot-%1-%2.png").arg(outputName, stamp);
+        }
+        return QDir(info.absoluteFilePath()).filePath(fileName);
+    }
+    if (info.absoluteFilePath().isEmpty()) {
+        if (error) {
+            *error = QStringLiteral("empty output path");
+        }
+        return QString();
+    }
+    return info.absoluteFilePath();
+}
+
+} // namespace
+
+void addHeadlessCaptureOptions(QCommandLineParser *parser)
+{
+    QCommandLineOption captureToOption(QStringLiteral("capture-to"),
+                                       QStringLiteral("Capture the screen and write it to the given file or directory without showing the UI."),
+                                       QStringLiteral("path"));
+    QCommandLineOption regionOption(QStringLiteral("region"),
+                                    QStringLiteral("Capture only the region x,y,width,height in logical screen coordinates."),
+                                    QStringLiteral("x,y,w,h"));
+    QCommandLineOption displayOption(QStringLiteral("display"),
+                                     QStringLiteral("Capture a specific output by monitor name."),
+                                     QStringLiteral("name"));
+    QCommandLineOption includeCursorOption(QStringLiteral("include-cursor"),
+                                           QStringLiteral("Draw the mouse cursor into the captured image."));
+    QCommandLineOption listDisplaysOption(QStringLiteral("list-displays"),
+                                          QStringLiteral("Print the available outputs as JSON and exit."));
+    QCommandLineOption outputNameOption(QStringLiteral("output-name"),
+                                        QStringLiteral("Base file name (without extension) used when the capture path is a directory."),
+                                        QStringLiteral("name"));
+    parser->addOption(captureToOption);
+    parser->addOption(regionOption);
+    parser->addOption(displayOption);
+    parser->addOption(includeCursorOption);
+    parser->addOption(listDisplaysOption);
+    parser->addOption(outputNameOption);
+}
+
+int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
+{
+    QTextStream out(stdout);
+    QTextStream err(stderr);
+
+    const bool wantListDisplays = parser.isSet(QStringLiteral("list-displays"));
+    const bool wantCapture = parser.isSet(QStringLiteral("capture-to"));
+    if (!wantListDisplays && !wantCapture) {
+        return -1;
+    }
+
+    if (wantListDisplays) {
+        out << displaysJson() << '\n';
+        out.flush();
+        if (wantCapture) {
+            err << "--list-displays and --capture-to cannot be combined.\n";
+            return 1;
+        }
+        return 0;
+    }
+
+    if (parser.positionalArguments().size() > 0) {
+        err << "--capture-to cannot be combined with an image file argument.\n";
+        return 1;
+    }
+
+    CaptureRequest request;
+    request.allOutputs = parser.isSet(QStringLiteral("all-outputs"));
+    request.includeCursor = parser.isSet(QStringLiteral("include-cursor"));
+    request.allowInteractivePortal = false;
+    request.hideOwnWindows = false;
+
+    if (parser.isSet(QStringLiteral("region"))) {
+        const std::optional<QRect> region = parseRegion(parser.value(QStringLiteral("region")));
+        if (!region.has_value()) {
+            err << "--region expects a comma-separated rectangle x,y,width,height.\n";
+            return 1;
+        }
+        if (request.allOutputs) {
+            err << "--region cannot be combined with --all-outputs.\n";
+            return 1;
+        }
+        request.sourceGeometry = region.value();
+    }
+
+    const QString displayName = parser.value(QStringLiteral("display")).trimmed();
+    if (!displayName.isEmpty()) {
+        request.preferredOutputName = displayName;
+    }
+
+    const CaptureResult result = captureScreenFrame(request);
+
+    if (result.image.isNull()) {
+        err << result.error << '\n';
+        out << QJsonDocument(QJsonObject{{QStringLiteral("path"), QJsonValue::Null},
+                                         {QStringLiteral("width"), 0},
+                                         {QStringLiteral("height"), 0},
+                                         {QStringLiteral("output"), QJsonValue::Null},
+                                         {QStringLiteral("error"), result.error}})
+                   .toJson(QJsonDocument::Compact)
+            << '\n';
+        out.flush();
+        return 1;
+    }
+
+    QString resolveError;
+    const QString baseName = parser.value(QStringLiteral("output-name")).trimmed();
+    const QString outputPath = resolveOutputPath(parser.value(QStringLiteral("capture-to")),
+                                                 baseName.isEmpty() ? result.outputName : baseName,
+                                                 &resolveError);
+    if (outputPath.isEmpty()) {
+        err << resolveError << '\n';
+        return 1;
+    }
+
+    QImageWriter writer(outputPath, QStringLiteral("png"));
+    if (!writer.write(result.image)) {
+        const QString writeError = writer.errorString();
+        err << "failed to write capture to " << outputPath << ": " << writeError << '\n';
+        out << QJsonDocument(QJsonObject{{QStringLiteral("path"), QJsonValue::Null},
+                                         {QStringLiteral("width"), 0},
+                                         {QStringLiteral("height"), 0},
+                                         {QStringLiteral("output"), QJsonValue::Null},
+                                         {QStringLiteral("error"), writeError}})
+                   .toJson(QJsonDocument::Compact)
+            << '\n';
+        out.flush();
+        return 1;
+    }
+
+    out << QJsonDocument(QJsonObject{{QStringLiteral("path"), outputPath},
+                                     {QStringLiteral("width"), result.image.width()},
+                                     {QStringLiteral("height"), result.image.height()},
+                                     {QStringLiteral("output"), result.outputName.isEmpty() ? QJsonValue::Null : QJsonValue(result.outputName)},
+                                     {QStringLiteral("error"), QJsonValue::Null}})
+               .toJson(QJsonDocument::Compact)
+        << '\n';
+    out.flush();
+    return 0;
+}
+
+} // namespace markshot::cli

--- a/src/cli/headless_capture.cpp
+++ b/src/cli/headless_capture.cpp
@@ -13,6 +13,7 @@
 #include <QScreen>
 #include <QTextStream>
 
+#include <cstdio>
 #include <optional>
 
 namespace markshot::cli {
@@ -162,6 +163,18 @@ int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
     const QString displayName = parser.value(QStringLiteral("display")).trimmed();
     if (!displayName.isEmpty()) {
         request.preferredOutputName = displayName;
+        // When no explicit --region is given, crop to the named output so
+        // portal-based backends capture that monitor instead of the whole
+        // virtual desktop.
+        if (!request.sourceGeometry.isValid()) {
+            const QList<QScreen *> screens = QGuiApplication::screens();
+            for (QScreen *screen : screens) {
+                if (screen && screen->name() == displayName) {
+                    request.sourceGeometry = screen->geometry();
+                    break;
+                }
+            }
+        }
     }
 
     const CaptureResult result = captureScreenFrame(request);
@@ -189,7 +202,7 @@ int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
         return 1;
     }
 
-    QImageWriter writer(outputPath, QStringLiteral("png"));
+    QImageWriter writer(outputPath, QByteArrayLiteral("png"));
     if (!writer.write(result.image)) {
         const QString writeError = writer.errorString();
         err << "failed to write capture to " << outputPath << ": " << writeError << '\n';

--- a/src/cli/headless_capture.cpp
+++ b/src/cli/headless_capture.cpp
@@ -4,6 +4,7 @@
 
 #include <QDateTime>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QGuiApplication>
 #include <QImageWriter>
@@ -64,14 +65,18 @@ QByteArray displaysJson()
     return QJsonDocument(root).toJson(QJsonDocument::Compact);
 }
 
-// Resolves the final output path. When the user passes a directory, a
-// timestamped file name is generated inside it.
+// Resolves the final output path. When the user passes a directory (or a path
+// ending with a separator that does not yet exist), a timestamped file name is
+// generated inside it.
 QString resolveOutputPath(const QString &captureTo, const QString &outputName, QString *error)
 {
     QFileInfo info(captureTo);
-    if (info.isDir()) {
+    const bool looksLikeDirectory = info.isDir()
+        || (captureTo.endsWith(QLatin1Char('/')) || captureTo.endsWith(QLatin1Char('\\')));
+    if (looksLikeDirectory) {
+        QDir().mkpath(info.absoluteFilePath());
         const QString stamp =
-            QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss"));
+            QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss-zzz"));
         QString fileName = QStringLiteral("mark-shot-%1.png").arg(stamp);
         if (!outputName.isEmpty()) {
             fileName = QStringLiteral("mark-shot-%1-%2.png").arg(outputName, stamp);
@@ -87,6 +92,13 @@ QString resolveOutputPath(const QString &captureTo, const QString &outputName, Q
     return info.absoluteFilePath();
 }
 
+// Returns true when captureTo looks like an existing directory (the only form
+// supported for multi-display capture).
+bool isDirectoryTarget(const QString &captureTo)
+{
+    return QFileInfo(captureTo).isDir();
+}
+
 // Builds the base CaptureRequest for headless mode. Shared by the single and
 // multi-display paths.
 CaptureRequest baseCaptureRequest(const QCommandLineParser &parser)
@@ -99,6 +111,31 @@ CaptureRequest baseCaptureRequest(const QCommandLineParser &parser)
     return request;
 }
 
+// Returns the geometry of the named display, or a default-constructed QRect
+// when no such display exists.
+QRect displayGeometry(const QString &displayName)
+{
+    const QList<QScreen *> screens = QGuiApplication::screens();
+    for (QScreen *screen : screens) {
+        if (screen && screen->name() == displayName) {
+            return screen->geometry();
+        }
+    }
+    return {};
+}
+
+// Verifies that every requested display name exists. Returns the first
+// offending name, or an empty string when all names are valid.
+QString firstUnknownDisplay(const QStringList &displayNames)
+{
+    for (const QString &displayName : displayNames) {
+        if (displayGeometry(displayName).isNull()) {
+            return displayName;
+        }
+    }
+    return {};
+}
+
 // Applies a display name: prefers that output and, when no explicit region is
 // given, crops to the output geometry so portal backends capture that monitor
 // instead of the whole virtual desktop.
@@ -109,12 +146,9 @@ void applyDisplayToRequest(CaptureRequest *request, const QString &displayName)
     }
     request->preferredOutputName = displayName;
     if (!request->sourceGeometry.isValid()) {
-        const QList<QScreen *> screens = QGuiApplication::screens();
-        for (QScreen *screen : screens) {
-            if (screen && screen->name() == displayName) {
-                request->sourceGeometry = screen->geometry();
-                break;
-            }
+        const QRect geometry = displayGeometry(displayName);
+        if (!geometry.isNull()) {
+            request->sourceGeometry = geometry;
         }
     }
 }
@@ -155,6 +189,7 @@ QJsonObject captureOneToFile(const CaptureRequest &request,
     QImageWriter writer(outputPath, QByteArrayLiteral("png"));
     if (!writer.write(result.image)) {
         const QString writeError = writer.errorString();
+        QFile::remove(outputPath);
         if (err) {
             *err << "failed to write capture to " << outputPath << ": " << writeError << '\n';
         }
@@ -165,10 +200,17 @@ QJsonObject captureOneToFile(const CaptureRequest &request,
                 {QStringLiteral("error"), writeError}};
     }
 
+    // Propagate the requested display name when the backend did not fill it
+    // (QScreen-based backends return an empty outputName).
+    QString effectiveOutput = result.outputName;
+    if (effectiveOutput.isEmpty() && !request.preferredOutputName.isEmpty()) {
+        effectiveOutput = request.preferredOutputName;
+    }
+
     return {{QStringLiteral("path"), outputPath},
             {QStringLiteral("width"), result.image.width()},
             {QStringLiteral("height"), result.image.height()},
-            {QStringLiteral("output"), result.outputName.isEmpty() ? QJsonValue::Null : QJsonValue(result.outputName)},
+            {QStringLiteral("output"), effectiveOutput.isEmpty() ? QJsonValue::Null : QJsonValue(effectiveOutput)},
             {QStringLiteral("error"), QJsonValue::Null}};
 }
 
@@ -226,24 +268,47 @@ int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
         return 1;
     }
 
-    CaptureRequest request = baseCaptureRequest(parser);
+    const QStringList displayNames = parser.values(QStringLiteral("display"));
+    const QString captureTo = parser.value(QStringLiteral("capture-to"));
+    const QString outputName = parser.value(QStringLiteral("output-name")).trimmed();
+    const bool hasRegion = parser.isSet(QStringLiteral("region"));
+    const bool allOutputs = parser.isSet(QStringLiteral("all-outputs"));
 
-    if (parser.isSet(QStringLiteral("region"))) {
+    // Reject semantically conflicting option combinations early so the user
+    // gets a clear error instead of silently capturing the wrong pixels.
+    if (allOutputs && !displayNames.isEmpty()) {
+        err << "--all-outputs cannot be combined with --display.\n";
+        return 1;
+    }
+    if (hasRegion && displayNames.size() > 1) {
+        err << "--region cannot be combined with multiple --display options.\n";
+        return 1;
+    }
+    if (displayNames.size() > 1 && !isDirectoryTarget(captureTo)) {
+        err << "--capture-to must be an existing directory when capturing multiple displays.\n";
+        return 1;
+    }
+    const QString unknownDisplay = firstUnknownDisplay(displayNames);
+    if (!unknownDisplay.isEmpty()) {
+        err << "unknown display: " << unknownDisplay << ". Use --list-displays to see valid names.\n";
+        return 1;
+    }
+
+    CaptureRequest request = baseCaptureRequest(parser);
+    request.allOutputs = allOutputs;
+
+    if (hasRegion) {
         const std::optional<QRect> region = parseRegion(parser.value(QStringLiteral("region")));
         if (!region.has_value()) {
             err << "--region expects a comma-separated rectangle x,y,width,height.\n";
             return 1;
         }
-        if (request.allOutputs) {
+        if (allOutputs) {
             err << "--region cannot be combined with --all-outputs.\n";
             return 1;
         }
         request.sourceGeometry = region.value();
     }
-
-    const QStringList displayNames = parser.values(QStringLiteral("display"));
-    const QString captureTo = parser.value(QStringLiteral("capture-to"));
-    const QString outputName = parser.value(QStringLiteral("output-name")).trimmed();
 
     // Multiple --display: capture each monitor to its own PNG and print a
     // {"captures":[...]} JSON array. This enables multi-screen selection for
@@ -253,9 +318,7 @@ int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
         bool anyFailed = false;
         for (const QString &displayName : displayNames) {
             CaptureRequest displayRequest = request;
-            if (!request.allOutputs) {
-                applyDisplayToRequest(&displayRequest, displayName);
-            }
+            applyDisplayToRequest(&displayRequest, displayName);
             const QString baseName = outputName.isEmpty()
                 ? displayName
                 : QStringLiteral("%1-%2").arg(outputName, displayName);
@@ -273,7 +336,7 @@ int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
     }
 
     // Single display (or none): keep the original compact single-object JSON.
-    if (!request.allOutputs && !displayNames.isEmpty()) {
+    if (!displayNames.isEmpty()) {
         applyDisplayToRequest(&request, displayNames.first());
     }
 

--- a/src/cli/headless_capture.cpp
+++ b/src/cli/headless_capture.cpp
@@ -87,6 +87,91 @@ QString resolveOutputPath(const QString &captureTo, const QString &outputName, Q
     return info.absoluteFilePath();
 }
 
+// Builds the base CaptureRequest for headless mode. Shared by the single and
+// multi-display paths.
+CaptureRequest baseCaptureRequest(const QCommandLineParser &parser)
+{
+    CaptureRequest request;
+    request.allOutputs = parser.isSet(QStringLiteral("all-outputs"));
+    request.includeCursor = parser.isSet(QStringLiteral("include-cursor"));
+    request.allowInteractivePortal = false;
+    request.hideOwnWindows = false;
+    return request;
+}
+
+// Applies a display name: prefers that output and, when no explicit region is
+// given, crops to the output geometry so portal backends capture that monitor
+// instead of the whole virtual desktop.
+void applyDisplayToRequest(CaptureRequest *request, const QString &displayName)
+{
+    if (displayName.isEmpty() || !request) {
+        return;
+    }
+    request->preferredOutputName = displayName;
+    if (!request->sourceGeometry.isValid()) {
+        const QList<QScreen *> screens = QGuiApplication::screens();
+        for (QScreen *screen : screens) {
+            if (screen && screen->name() == displayName) {
+                request->sourceGeometry = screen->geometry();
+                break;
+            }
+        }
+    }
+}
+
+// Captures one frame to a PNG and returns a compact JSON summary object.
+// On failure an object with a null path and an error message is returned.
+QJsonObject captureOneToFile(const CaptureRequest &request,
+                             const QString &captureTo,
+                             const QString &baseName,
+                             QTextStream *err)
+{
+    const CaptureResult result = captureScreenFrame(request);
+
+    if (result.image.isNull()) {
+        if (err) {
+            *err << result.error << '\n';
+        }
+        return {{QStringLiteral("path"), QJsonValue::Null},
+                {QStringLiteral("width"), 0},
+                {QStringLiteral("height"), 0},
+                {QStringLiteral("output"), QJsonValue::Null},
+                {QStringLiteral("error"), result.error}};
+    }
+
+    QString resolveError;
+    const QString outputPath = resolveOutputPath(captureTo, baseName, &resolveError);
+    if (outputPath.isEmpty()) {
+        if (err) {
+            *err << resolveError << '\n';
+        }
+        return {{QStringLiteral("path"), QJsonValue::Null},
+                {QStringLiteral("width"), 0},
+                {QStringLiteral("height"), 0},
+                {QStringLiteral("output"), QJsonValue::Null},
+                {QStringLiteral("error"), resolveError}};
+    }
+
+    QImageWriter writer(outputPath, QByteArrayLiteral("png"));
+    if (!writer.write(result.image)) {
+        const QString writeError = writer.errorString();
+        if (err) {
+            *err << "failed to write capture to " << outputPath << ": " << writeError << '\n';
+        }
+        return {{QStringLiteral("path"), QJsonValue::Null},
+                {QStringLiteral("width"), 0},
+                {QStringLiteral("height"), 0},
+                {QStringLiteral("output"), QJsonValue::Null},
+                {QStringLiteral("error"), writeError}};
+    }
+
+    return {{QStringLiteral("path"), outputPath},
+            {QStringLiteral("width"), result.image.width()},
+            {QStringLiteral("height"), result.image.height()},
+            {QStringLiteral("output"), result.outputName.isEmpty() ? QJsonValue::Null : QJsonValue(result.outputName)},
+            {QStringLiteral("error"), QJsonValue::Null}};
+}
+
 } // namespace
 
 void addHeadlessCaptureOptions(QCommandLineParser *parser)
@@ -98,7 +183,7 @@ void addHeadlessCaptureOptions(QCommandLineParser *parser)
                                     QStringLiteral("Capture only the region x,y,width,height in logical screen coordinates."),
                                     QStringLiteral("x,y,w,h"));
     QCommandLineOption displayOption(QStringLiteral("display"),
-                                     QStringLiteral("Capture a specific output by monitor name."),
+                                     QStringLiteral("Capture a specific output by monitor name. May be repeated to capture several monitors at once."),
                                      QStringLiteral("name"));
     QCommandLineOption includeCursorOption(QStringLiteral("include-cursor"),
                                            QStringLiteral("Draw the mouse cursor into the captured image."));
@@ -141,11 +226,7 @@ int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
         return 1;
     }
 
-    CaptureRequest request;
-    request.allOutputs = parser.isSet(QStringLiteral("all-outputs"));
-    request.includeCursor = parser.isSet(QStringLiteral("include-cursor"));
-    request.allowInteractivePortal = false;
-    request.hideOwnWindows = false;
+    CaptureRequest request = baseCaptureRequest(parser);
 
     if (parser.isSet(QStringLiteral("region"))) {
         const std::optional<QRect> region = parseRegion(parser.value(QStringLiteral("region")));
@@ -160,72 +241,46 @@ int runHeadlessCaptureIfRequested(const QCommandLineParser &parser)
         request.sourceGeometry = region.value();
     }
 
-    const QString displayName = parser.value(QStringLiteral("display")).trimmed();
-    if (!displayName.isEmpty()) {
-        request.preferredOutputName = displayName;
-        // When no explicit --region is given, crop to the named output so
-        // portal-based backends capture that monitor instead of the whole
-        // virtual desktop.
-        if (!request.sourceGeometry.isValid()) {
-            const QList<QScreen *> screens = QGuiApplication::screens();
-            for (QScreen *screen : screens) {
-                if (screen && screen->name() == displayName) {
-                    request.sourceGeometry = screen->geometry();
-                    break;
-                }
+    const QStringList displayNames = parser.values(QStringLiteral("display"));
+    const QString captureTo = parser.value(QStringLiteral("capture-to"));
+    const QString outputName = parser.value(QStringLiteral("output-name")).trimmed();
+
+    // Multiple --display: capture each monitor to its own PNG and print a
+    // {"captures":[...]} JSON array. This enables multi-screen selection for
+    // agents and scripts.
+    if (displayNames.size() > 1) {
+        QJsonArray captures;
+        bool anyFailed = false;
+        for (const QString &displayName : displayNames) {
+            CaptureRequest displayRequest = request;
+            if (!request.allOutputs) {
+                applyDisplayToRequest(&displayRequest, displayName);
             }
+            const QString baseName = outputName.isEmpty()
+                ? displayName
+                : QStringLiteral("%1-%2").arg(outputName, displayName);
+            const QJsonObject one = captureOneToFile(displayRequest, captureTo, baseName, &err);
+            if (one.value(QStringLiteral("error")).isString()) {
+                anyFailed = true;
+            }
+            captures.append(one);
         }
-    }
-
-    const CaptureResult result = captureScreenFrame(request);
-
-    if (result.image.isNull()) {
-        err << result.error << '\n';
-        out << QJsonDocument(QJsonObject{{QStringLiteral("path"), QJsonValue::Null},
-                                         {QStringLiteral("width"), 0},
-                                         {QStringLiteral("height"), 0},
-                                         {QStringLiteral("output"), QJsonValue::Null},
-                                         {QStringLiteral("error"), result.error}})
+        out << QJsonDocument(QJsonObject{{QStringLiteral("captures"), captures}})
                    .toJson(QJsonDocument::Compact)
             << '\n';
         out.flush();
-        return 1;
+        return anyFailed ? 1 : 0;
     }
 
-    QString resolveError;
-    const QString baseName = parser.value(QStringLiteral("output-name")).trimmed();
-    const QString outputPath = resolveOutputPath(parser.value(QStringLiteral("capture-to")),
-                                                 baseName.isEmpty() ? result.outputName : baseName,
-                                                 &resolveError);
-    if (outputPath.isEmpty()) {
-        err << resolveError << '\n';
-        return 1;
+    // Single display (or none): keep the original compact single-object JSON.
+    if (!request.allOutputs && !displayNames.isEmpty()) {
+        applyDisplayToRequest(&request, displayNames.first());
     }
 
-    QImageWriter writer(outputPath, QByteArrayLiteral("png"));
-    if (!writer.write(result.image)) {
-        const QString writeError = writer.errorString();
-        err << "failed to write capture to " << outputPath << ": " << writeError << '\n';
-        out << QJsonDocument(QJsonObject{{QStringLiteral("path"), QJsonValue::Null},
-                                         {QStringLiteral("width"), 0},
-                                         {QStringLiteral("height"), 0},
-                                         {QStringLiteral("output"), QJsonValue::Null},
-                                         {QStringLiteral("error"), writeError}})
-                   .toJson(QJsonDocument::Compact)
-            << '\n';
-        out.flush();
-        return 1;
-    }
-
-    out << QJsonDocument(QJsonObject{{QStringLiteral("path"), outputPath},
-                                     {QStringLiteral("width"), result.image.width()},
-                                     {QStringLiteral("height"), result.image.height()},
-                                     {QStringLiteral("output"), result.outputName.isEmpty() ? QJsonValue::Null : QJsonValue(result.outputName)},
-                                     {QStringLiteral("error"), QJsonValue::Null}})
-               .toJson(QJsonDocument::Compact)
-        << '\n';
+    const QJsonObject single = captureOneToFile(request, captureTo, outputName, &err);
+    out << QJsonDocument(single).toJson(QJsonDocument::Compact) << '\n';
     out.flush();
-    return 0;
+    return single.value(QStringLiteral("error")).isString() ? 1 : 0;
 }
 
 } // namespace markshot::cli

--- a/src/cli/headless_capture.h
+++ b/src/cli/headless_capture.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QCommandLineParser>
+
+namespace markshot::cli {
+
+// Registers the headless capture options (--capture-to, --region, --display,
+// --include-cursor, --list-displays) on the given parser.
+void addHeadlessCaptureOptions(QCommandLineParser *parser);
+
+// Runs the headless capture flow when --capture-to or --list-displays is
+// present. Returns an application exit code, or -1 when no headless option is
+// set and normal startup should continue.
+int runHeadlessCaptureIfRequested(const QCommandLineParser &parser);
+
+} // namespace markshot::cli

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,7 +175,6 @@ int main(int argc, char *argv[])
     markshot::debugLog("config",
                        "debug enabled path=%s",
                        markshot::debugLogPath().toUtf8().constData());
-
     const int headlessExitCode = markshot::cli::runHeadlessCaptureIfRequested(parser);
     if (headlessExitCode >= 0) {
         return headlessExitCode;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,11 +140,6 @@ int main(int argc, char *argv[])
         return markshot::cli::printRecordingStatus();
     }
 
-    const int headlessExitCode = markshot::cli::runHeadlessCaptureIfRequested(parser);
-    if (headlessExitCode >= 0) {
-        return headlessExitCode;
-    }
-
     const QStringList positionalArguments = parser.positionalArguments();
     if (positionalArguments.size() > 1) {
         QMessageBox::critical(nullptr, QStringLiteral("Mark Shot"), MS_TR("Only one image file can be opened at a time."));
@@ -180,6 +175,11 @@ int main(int argc, char *argv[])
     markshot::debugLog("config",
                        "debug enabled path=%s",
                        markshot::debugLogPath().toUtf8().constData());
+
+    const int headlessExitCode = markshot::cli::runHeadlessCaptureIfRequested(parser);
+    if (headlessExitCode >= 0) {
+        return headlessExitCode;
+    }
 
     QString configDefaultToolWarning;
     markshot::DefaultTools defaultTools = markshot::configuredDefaultTools(&configDefaultToolWarning);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "capture_freeze_scope.h"
 #include "capture_own_windows_policy.h"
 #include "capture_session_launcher.h"
+#include "cli/headless_capture.h"
 #include "cli/image_pin_launch.h"
 #include "cli/recording_cli.h"
 #include "debug_log.h"
@@ -129,6 +130,7 @@ int main(int argc, char *argv[])
     parser.addOption(debugOption);
     parser.addOption(noDebugOption);
     parser.addOption(debugLogOption);
+    markshot::cli::addHeadlessCaptureOptions(&parser);
     parser.process(app);
 
     if (parser.isSet(stopRecordingOption)) {
@@ -136,6 +138,11 @@ int main(int argc, char *argv[])
     }
     if (parser.isSet(recordingStatusOption)) {
         return markshot::cli::printRecordingStatus();
+    }
+
+    const int headlessExitCode = markshot::cli::runHeadlessCaptureIfRequested(parser);
+    if (headlessExitCode >= 0) {
+        return headlessExitCode;
     }
 
     const QStringList positionalArguments = parser.positionalArguments();

--- a/src/pipewire/pipewire_buffer_data_types.cpp
+++ b/src/pipewire/pipewire_buffer_data_types.cpp
@@ -1,21 +1,35 @@
 #include "pipewire/pipewire_buffer_data_types.h"
 
+#include <QtGlobal>
+
+#ifdef HAVE_PIPEWIRE
 #include <spa/buffer/buffer.h>
+#endif
 
 namespace markshot::pipewire {
 
 std::uint32_t bufferDataTypeMask(bool hasModifier)
 {
+#ifdef HAVE_PIPEWIRE
     return hasModifier
         ? (1u << SPA_DATA_DmaBuf)
         : ((1u << SPA_DATA_MemPtr) | (1u << SPA_DATA_MemFd));
+#else
+    Q_UNUSED(hasModifier);
+    return 0;
+#endif
 }
 
 std::array<bool, 2> modifierPreference(bool rawStreamMode)
 {
+#ifdef HAVE_PIPEWIRE
     return rawStreamMode
         ? std::array<bool, 2>{false, true}
         : std::array<bool, 2>{true, false};
+#else
+    Q_UNUSED(rawStreamMode);
+    return {false, false};
+#endif
 }
 
 }  // namespace markshot::pipewire


### PR DESCRIPTION
## Summary

Adds a non-interactive (headless) capture path to the CLI, useful for scripts, CI automation, and integrating mark-shot as a subprocess.

New options:
- `--capture-to <path>`: capture the screen and write a PNG without opening the annotation UI (file or directory target)
- `--region <x,y,w,h>`: capture only a logical screen region
- `--display <name>`: capture a specific monitor (resolved to its screen geometry so portal backends crop correctly)
- `--include-cursor`: draw the mouse cursor into the captured frame
- `--output-name <name>`: base file name when the capture path is a directory
- `--list-displays`: print available outputs as JSON and exit

The result is reported as compact JSON on stdout (path, width, height, output, error), with errors on stderr and a non-zero exit code.

## Design

Headless capture reuses `captureScreenFrame()`, so every existing backend keeps working (QScreen, xdg-desktop-portal, grim, KWin, GNOME helpers, Windows Graphics Capture). No interactive portal prompts are used.

## Additional fix

`src/pipewire/pipewire_buffer_data_types.cpp` was compiled unconditionally on Linux but includes `spa/buffer/buffer.h`, breaking builds on machines without libpipewire development files. The implementation is now guarded with `HAVE_PIPEWIRE`.

## Testing

- Built on Linux (Qt 6.9/6.11, no PipeWire dev headers) — previously failing, now compiles.
- `--list-displays`, `--capture-to` (full screen, region, per-display, directory + `--output-name`) verified on a Wayland (GNOME) session via xdg-desktop-portal.
- `ctest`: 38/38 passing.