### PR TITLE
feat(text): precise font size and style control for the text tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It captures screen frames instantly and opens an interactive fullscreen overlay,
   - Supports dynamic, ultra-large font sizing with fluid adjustment via scroll wheel or property sliders.
   - Implements a physical width buffer to prevent unexpected wrapping across extreme scales.
   - **Diagonal handles** scale font size and boundary box proportionally; **side borders** only adjust wrap width.
+  - **Precise font control**: the text font panel provides an exact point-size input (8-300 pt), a font family list, and Bold / Italic toggles. All of them apply to new text, the inline editor, and existing annotations, and persist across sessions.
 - **Laser Pointer**: Dedicated presentation tool with pen traces that dissolve smoothly over time.
 - **Auto-Increment Marker**: Click to stamp sequential numbered markers.
 - **Mosaic**: Applies high-fidelity acrylic frost blur to obscure sensitive information.

--- a/src/annotation_state_store.cpp
+++ b/src/annotation_state_store.cpp
@@ -34,6 +34,8 @@ constexpr const char *kKeyArrowStyle = "arrowStyle";
 constexpr const char *kKeyHighlighterStyle = "highlighterStyle";
 constexpr const char *kKeyNumberStyle = "numberStyle";
 constexpr const char *kKeyTextFontFamily = "textFontFamily";
+constexpr const char *kKeyTextFontWeight = "textFontWeight";
+constexpr const char *kKeyTextItalic = "textItalic";
 constexpr const char *kKeyTextBackgroundColor = "textBackgroundColor";
 
 /// @brief 读取 JSON 中颜色字符串为 QColor
@@ -176,6 +178,16 @@ AnnotationState loadAnnotationState()
     if (fontValue.isString()) {
         state.textFontFamily = fontValue.toString();
     }
+    const QJsonValue fontWeightValue = root.value(QString::fromLatin1(kKeyTextFontWeight));
+    if (fontWeightValue.isDouble()) {
+        const int weight = fontWeightValue.toInt();
+        state.textFontWeight = static_cast<QFont::Weight>(
+            std::clamp(weight, static_cast<int>(QFont::Thin), static_cast<int>(QFont::Black)));
+    }
+    const QJsonValue italicValue = root.value(QString::fromLatin1(kKeyTextItalic));
+    if (italicValue.isBool()) {
+        state.textItalic = italicValue.toBool();
+    }
 
     return state;
 }
@@ -209,6 +221,8 @@ bool saveAnnotationState(const AnnotationState &state)
     root.insert(QString::fromLatin1(kKeyHighlighterStyle), static_cast<int>(state.highlighterStyle));
     root.insert(QString::fromLatin1(kKeyNumberStyle), static_cast<int>(state.numberStyle));
     root.insert(QString::fromLatin1(kKeyTextFontFamily), state.textFontFamily);
+    root.insert(QString::fromLatin1(kKeyTextFontWeight), static_cast<int>(state.textFontWeight));
+    root.insert(QString::fromLatin1(kKeyTextItalic), state.textItalic);
     root.insert(QString::fromLatin1(kKeyTextBackgroundColor), colorToJson(state.textBackgroundColor));
 
     // 2. 通过 QSaveFile 原子写入,避免崩溃时残留半截 JSON

--- a/src/annotation_state_store.h
+++ b/src/annotation_state_store.h
@@ -40,6 +40,8 @@ struct AnnotationState {
 
     // 文本相关
     QString textFontFamily;
+    QFont::Weight textFontWeight = QFont::DemiBold;
+    bool textItalic = false;
     QColor textBackgroundColor = QColor(0, 0, 0, 0);
 };
 

--- a/src/pipewire/pipewire_buffer_data_types.cpp
+++ b/src/pipewire/pipewire_buffer_data_types.cpp
@@ -1,21 +1,35 @@
 #include "pipewire/pipewire_buffer_data_types.h"
 
+#include <QtGlobal>
+
+#ifdef HAVE_PIPEWIRE
 #include <spa/buffer/buffer.h>
+#endif
 
 namespace markshot::pipewire {
 
 std::uint32_t bufferDataTypeMask(bool hasModifier)
 {
+#ifdef HAVE_PIPEWIRE
     return hasModifier
         ? (1u << SPA_DATA_DmaBuf)
         : ((1u << SPA_DATA_MemPtr) | (1u << SPA_DATA_MemFd));
+#else
+    Q_UNUSED(hasModifier);
+    return 0;
+#endif
 }
 
 std::array<bool, 2> modifierPreference(bool rawStreamMode)
 {
+#ifdef HAVE_PIPEWIRE
     return rawStreamMode
         ? std::array<bool, 2>{false, true}
         : std::array<bool, 2>{true, false};
+#else
+    Q_UNUSED(rawStreamMode);
+    return {false, false};
+#endif
 }
 
 }  // namespace markshot::pipewire

--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -2,6 +2,7 @@
 
 #include <QColor>
 #include <QElapsedTimer>
+#include <QFont>
 #include <QImage>
 #include <QKeySequence>
 #include <QPointF>
@@ -17,6 +18,10 @@
 #include "toolbar_appearance_config.h"
 #include "ui/theme.h"
 #include "window_detection.h"
+
+class QListWidget;
+class QSpinBox;
+class QToolButton;
 
 #include <array>
 #include <optional>
@@ -287,6 +292,8 @@ private:
         MagnifierShape magnifierShape = MagnifierShape::Circle;
         NumberStyle numberStyle = NumberStyle::Arabic;
         QString fontFamily = markshot::theme::textFontFamily();
+        QFont::Weight fontWeight = QFont::DemiBold;
+        bool textItalic = false;
         RectangleStyle rectangleStyle = RectangleStyle::Stroke;
     };
 
@@ -496,6 +503,9 @@ private:
     void setSelectedMagnifierShape(MagnifierShape shape);
     void toggleMagnifierShape();
     void setSelectedTextFontFamily(const QString &fontFamily);
+    void setSelectedTextFontSize(int pointSize);
+    void setSelectedTextBold(bool bold);
+    void setSelectedTextItalic(bool italic);
     void applyPropertyColor(QColor color);
     void deleteSelectedAnnotation();
     void openSelectedAnnotationColorPalette();
@@ -654,6 +664,8 @@ private:
     HighlighterStyle m_highlighterStyle = HighlighterStyle::StraightLine;
     NumberStyle m_numberStyle = NumberStyle::Arabic;
     QString m_textFontFamily = markshot::theme::textFontFamily();
+    QFont::Weight m_textWeight = QFont::DemiBold;
+    bool m_textItalic = false;
     QColor m_textBackgroundColor = QColor(0, 0, 0, 0);
     int m_nextNumber = 1;
     int m_nextAnnotationId = 1;
@@ -696,6 +708,9 @@ private:
     QPushButton *m_propertyFontButton = nullptr;
     QWidget *m_propertyFontPanel = nullptr;
     QListWidget *m_propertyFontList = nullptr;
+    QSpinBox *m_propertyFontSizeSpin = nullptr;
+    QToolButton *m_propertyFontBoldButton = nullptr;
+    QToolButton *m_propertyFontItalicButton = nullptr;
     QPushButton *m_propertyEditTextButton = nullptr;
     QWidget *m_propertyColorDialogPanel = nullptr;
     markshot::ui::ColorPicker *m_propertyColorPicker = nullptr;

--- a/src/shot_window_annotation_painting.cpp
+++ b/src/shot_window_annotation_painting.cpp
@@ -109,8 +109,9 @@ void ShotWindow::drawAnnotation(QPainter &painter, const Annotation &annotation,
         break;
     case Tool::Text: {
         QFont font = markshot::theme::textFont(qRound((19.0 + annotation.width) * scale),
-                                               QFont::DemiBold,
+                                               annotation.fontWeight,
                                                annotation.fontFamily);
+        font.setItalic(annotation.textItalic);
         QRectF backgroundRect = textContentRect(annotation, widgetCoordinates);
         QRectF textRect = backgroundRect.adjusted(kTextBackgroundPaddingX * scale,
                                                   kTextBackgroundPaddingY * scale,
@@ -572,9 +573,11 @@ void ShotWindow::beginTextAnnotation(QPointF imagePoint)
     m_draft.reset();
     m_textEditor->clear();
     m_textEditor->setStyleSheet(markshot::theme::textEditorStyleSheet(m_currentColor, m_textBackgroundColor, qRound(20.0 + m_textSize)));
-    m_textEditor->setFont(markshot::theme::textFont(qRound(20.0 + m_textSize),
-                                                    QFont::DemiBold,
-                                                    m_textFontFamily));
+    QFont editorFont = markshot::theme::textFont(qRound(20.0 + m_textSize),
+                                                 m_textWeight,
+                                                 m_textFontFamily);
+    editorFont.setItalic(m_textItalic);
+    m_textEditor->setFont(editorFont);
     m_textEditor->show();
     m_textEditor->raise();
     updateTextEditorGeometry();
@@ -598,9 +601,11 @@ void ShotWindow::beginEditingSelectedTextAnnotation()
     m_draft.reset();
     m_textEditor->setPlainText(annotation->text);
     m_textEditor->setStyleSheet(markshot::theme::textEditorStyleSheet(annotation->color, annotation->backgroundColor, qRound(20.0 + annotation->width)));
-    m_textEditor->setFont(markshot::theme::textFont(qRound(20.0 + annotation->width),
-                                                    QFont::DemiBold,
-                                                    annotation->fontFamily));
+    QFont editorFont = markshot::theme::textFont(qRound(20.0 + annotation->width),
+                                                 annotation->fontWeight,
+                                                 annotation->fontFamily);
+    editorFont.setItalic(annotation->textItalic);
+    m_textEditor->setFont(editorFont);
     if (m_annotationPropertyPanel) {
         m_annotationPropertyPanel->hide();
     }
@@ -638,6 +643,8 @@ void ShotWindow::commitTextEditor()
             pushHistorySnapshot();
             annotation->text = text;
             annotation->fontFamily = m_textEditor->font().family();
+            annotation->fontWeight = m_textEditor->font().weight();
+            annotation->textItalic = m_textEditor->font().italic();
             annotation->rect = textContentRect(*annotation, false);
             if (!annotation->points.isEmpty()) {
                 annotation->points[0] = annotation->rect.topLeft();
@@ -663,8 +670,12 @@ void ShotWindow::commitTextEditor()
         annotation.backgroundColor = m_textBackgroundColor;
         annotation.width = m_textSize;
         annotation.fontFamily = m_textEditor->font().family();
+        annotation.fontWeight = m_textEditor->font().weight();
+        annotation.textItalic = m_textEditor->font().italic();
         annotation.rect = textContentRect(annotation, false);
         m_textFontFamily = annotation.fontFamily;
+        m_textWeight = annotation.fontWeight;
+        m_textItalic = annotation.textItalic;
         m_annotations.append(annotation);
     }
 

--- a/src/shot_window_layout.cpp
+++ b/src/shot_window_layout.cpp
@@ -620,7 +620,7 @@ void ShotWindow::updateAnnotationPropertyPanel()
     if (m_propertyFontSizeSpin) {
         const QSignalBlocker blocker(m_propertyFontSizeSpin);
         m_propertyFontSizeSpin->setVisible(isTextPanel);
-        m_propertyFontSizeSpin->setValue(qRound(20.0 + panelWidth));
+        m_propertyFontSizeSpin->setValue(qRound(19.0 + panelWidth));
     }
     if (m_propertyFontBoldButton) {
         const QSignalBlocker blocker(m_propertyFontBoldButton);

--- a/src/shot_window_layout.cpp
+++ b/src/shot_window_layout.cpp
@@ -14,8 +14,9 @@ QRectF ShotWindow::textContentRect(const Annotation &annotation, bool widgetCoor
     const qreal wrapWidth = std::max<qreal>(16.0, baseRect.width() * scale - kTextBackgroundPaddingX * 2.0 * scale);
 
     QFont font = markshot::theme::textFont(qRound((19.0 + annotation.width) * scale),
-                                           QFont::DemiBold,
+                                           annotation.fontWeight,
                                            annotation.fontFamily);
+    font.setItalic(annotation.textItalic);
     QTextOption option;
     option.setWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     option.setAlignment(Qt::AlignLeft | Qt::AlignTop);
@@ -429,6 +430,10 @@ void ShotWindow::updateAnnotationPropertyPanel()
             ? annotation->numberStyle
             : m_numberStyle;
     const QString panelFontFamily = annotation ? annotation->fontFamily : m_textFontFamily;
+    const QFont::Weight panelFontWeight =
+        annotation && annotation->tool == Tool::Text ? annotation->fontWeight : m_textWeight;
+    const bool panelFontItalic =
+        annotation && annotation->tool == Tool::Text ? annotation->textItalic : m_textItalic;
 
     switch (panelTool) {
     case Tool::Move:
@@ -610,6 +615,22 @@ void ShotWindow::updateAnnotationPropertyPanel()
             m_propertyWidthSlider->setRange(qRound(kMinStrokeWidth), qRound(kMaxStrokeWidth));
         }
         m_propertyWidthSlider->setValue(qRound(panelWidth));
+    }
+    const bool isTextPanel = !groupSelection && panelTool == Tool::Text;
+    if (m_propertyFontSizeSpin) {
+        const QSignalBlocker blocker(m_propertyFontSizeSpin);
+        m_propertyFontSizeSpin->setVisible(isTextPanel);
+        m_propertyFontSizeSpin->setValue(qRound(20.0 + panelWidth));
+    }
+    if (m_propertyFontBoldButton) {
+        const QSignalBlocker blocker(m_propertyFontBoldButton);
+        m_propertyFontBoldButton->setVisible(isTextPanel);
+        m_propertyFontBoldButton->setChecked(panelFontWeight >= QFont::Bold);
+    }
+    if (m_propertyFontItalicButton) {
+        const QSignalBlocker blocker(m_propertyFontItalicButton);
+        m_propertyFontItalicButton->setVisible(isTextPanel);
+        m_propertyFontItalicButton->setChecked(panelFontItalic);
     }
     if (m_propertyOpacityLabel) {
         m_propertyOpacityLabel->setText(QStringLiteral("%1%").arg(panelOpacity));

--- a/src/shot_window_module.h
+++ b/src/shot_window_module.h
@@ -75,6 +75,7 @@
 #include <QShowEvent>
 #include <QSignalBlocker>
 #include <QSlider>
+#include <QSpinBox>
 #include <QStandardPaths>
 #include <QStyle>
 #include <QTemporaryFile>
@@ -85,6 +86,7 @@
 #include <QTextOption>
 #include <QThread>
 #include <QTimer>
+#include <QToolButton>
 #include <QTransform>
 #include <QUrl>
 #include <QVBoxLayout>

--- a/src/shot_window_property_panels.cpp
+++ b/src/shot_window_property_panels.cpp
@@ -602,12 +602,15 @@ void ShotWindow::setSelectedTextFontFamily(const QString &fontFamily)
 
 void ShotWindow::setSelectedTextFontSize(int pointSize)
 {
-    pointSize = std::clamp(pointSize, 8, 300);
+    // Rendered font size = 19 + annotation.width, so the spin box value maps
+    // directly to the final output size. The minimum width of 1.0 therefore
+    // corresponds to 20 pt; anything smaller is not representable.
+    pointSize = std::clamp(pointSize, 20, 300);
     if (m_propertyFontSizeSpin) {
         const QSignalBlocker blocker(m_propertyFontSizeSpin);
         m_propertyFontSizeSpin->setValue(pointSize);
     }
-    const qreal targetWidth = static_cast<qreal>(pointSize) - 20.0;
+    const qreal targetWidth = static_cast<qreal>(pointSize) - 19.0;
     setSelectedAnnotationWidth(qRound(targetWidth));
     if (m_textEditor && m_textEditor->isVisible()) {
         QFont font = m_textEditor->font();

--- a/src/shot_window_property_panels.cpp
+++ b/src/shot_window_property_panels.cpp
@@ -519,14 +519,22 @@ void ShotWindow::applyPropertyColor(QColor color)
         QColor editorColor = m_currentColor;
         QColor editorBackgroundColor = m_textBackgroundColor;
         qreal editorWidth = m_textSize;
+        QFont::Weight editorWeight = m_textWeight;
+        bool editorItalic = m_textItalic;
         if (m_editingTextAnnotationId.has_value()) {
             if (const Annotation *annotation = annotationById(*m_editingTextAnnotationId)) {
                 editorColor = annotation->color;
                 editorBackgroundColor = annotation->backgroundColor;
                 editorWidth = annotation->width;
+                editorWeight = annotation->fontWeight;
+                editorItalic = annotation->textItalic;
             }
         }
         m_textEditor->setStyleSheet(markshot::theme::textEditorStyleSheet(editorColor, editorBackgroundColor, qRound(20.0 + editorWidth)));
+        QFont editorFont = m_textEditor->font();
+        editorFont.setWeight(editorWeight);
+        editorFont.setItalic(editorItalic);
+        m_textEditor->setFont(editorFont);
     }
     updateColorPalettePreview();
     updateAnnotationPropertyPanel();
@@ -582,10 +590,120 @@ void ShotWindow::setSelectedTextFontFamily(const QString &fontFamily)
         }
         m_textFontFamily = fontFamily;
         if (m_textEditor && m_textEditor->isVisible() && !m_editingTextAnnotationId.has_value()) {
-            m_textEditor->setFont(markshot::theme::textFont(qRound(20.0 + m_textSize),
-                                                            QFont::DemiBold,
-                                                            m_textFontFamily));
+            QFont font = m_textEditor->font();
+            font.setFamily(m_textFontFamily);
+            m_textEditor->setFont(font);
         }
+    }
+    updateAnnotationPropertyPanel();
+    update();
+    persistAnnotationState();
+}
+
+void ShotWindow::setSelectedTextFontSize(int pointSize)
+{
+    pointSize = std::clamp(pointSize, 8, 300);
+    if (m_propertyFontSizeSpin) {
+        const QSignalBlocker blocker(m_propertyFontSizeSpin);
+        m_propertyFontSizeSpin->setValue(pointSize);
+    }
+    const qreal targetWidth = static_cast<qreal>(pointSize) - 20.0;
+    setSelectedAnnotationWidth(qRound(targetWidth));
+    if (m_textEditor && m_textEditor->isVisible()) {
+        QFont font = m_textEditor->font();
+        font.setPointSize(pointSize);
+        m_textEditor->setFont(font);
+    }
+    update();
+}
+
+void ShotWindow::setSelectedTextBold(bool bold)
+{
+    const QFont::Weight targetWeight = bold ? QFont::DemiBold : QFont::Normal;
+    const QVector<int> selectedIds = selectedAnnotationIds();
+    if (!selectedIds.isEmpty()) {
+        bool changed = false;
+        for (int id : selectedIds) {
+            const Annotation *annotation = annotationById(id);
+            if (annotation && annotation->tool == Tool::Text && annotation->fontWeight != targetWeight) {
+                changed = true;
+                break;
+            }
+        }
+        if (!changed) {
+            return;
+        }
+        pushHistorySnapshot();
+        for (int id : selectedIds) {
+            if (Annotation *annotation = annotationById(id);
+                annotation && annotation->tool == Tool::Text) {
+                annotation->fontWeight = targetWeight;
+            }
+        }
+    } else {
+        if (m_textWeight == targetWeight) {
+            return;
+        }
+        m_textWeight = targetWeight;
+    }
+    if (m_textEditor && m_textEditor->isVisible()) {
+        QFont font = m_textEditor->font();
+        if (m_editingTextAnnotationId.has_value()) {
+            if (const Annotation *annotation = annotationById(*m_editingTextAnnotationId)) {
+                font.setWeight(annotation->fontWeight);
+                font.setItalic(annotation->textItalic);
+            }
+        } else {
+            font.setWeight(m_textWeight);
+            font.setItalic(m_textItalic);
+        }
+        m_textEditor->setFont(font);
+    }
+    updateAnnotationPropertyPanel();
+    update();
+    persistAnnotationState();
+}
+
+void ShotWindow::setSelectedTextItalic(bool italic)
+{
+    const QVector<int> selectedIds = selectedAnnotationIds();
+    if (!selectedIds.isEmpty()) {
+        bool changed = false;
+        for (int id : selectedIds) {
+            const Annotation *annotation = annotationById(id);
+            if (annotation && annotation->tool == Tool::Text && annotation->textItalic != italic) {
+                changed = true;
+                break;
+            }
+        }
+        if (!changed) {
+            return;
+        }
+        pushHistorySnapshot();
+        for (int id : selectedIds) {
+            if (Annotation *annotation = annotationById(id);
+                annotation && annotation->tool == Tool::Text) {
+                annotation->textItalic = italic;
+            }
+        }
+    } else {
+        if (m_textItalic == italic) {
+            return;
+        }
+        m_textItalic = italic;
+    }
+    if (m_textEditor && m_textEditor->isVisible()) {
+        QFont font = m_textEditor->font();
+        if (m_editingTextAnnotationId.has_value()) {
+            if (const Annotation *annotation = annotationById(*m_editingTextAnnotationId)) {
+                font.setWeight(annotation->fontWeight);
+                font.setItalic(annotation->textItalic);
+            }
+        } else {
+            font.setWeight(m_textWeight);
+            font.setItalic(m_textItalic);
+        }
+        m_textEditor->setFont(font);
     }
     updateAnnotationPropertyPanel();
     update();

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -407,9 +407,9 @@ ShotWindow::ShotWindow(QImage frozenFrame,
     });
     fontPanelLayout->addWidget(m_propertyFontList);
 
-    // 字号精确输入（最终点大小 = 20 + 文本宽度偏移）
+    // 字号精确输入（最终渲染点大小 = 19 + 文本宽度偏移）
     m_propertyFontSizeSpin = new QSpinBox(m_propertyFontPanel);
-    m_propertyFontSizeSpin->setRange(8, 300);
+    m_propertyFontSizeSpin->setRange(20, 300);
     m_propertyFontSizeSpin->setSingleStep(1);
     m_propertyFontSizeSpin->setSuffix(QStringLiteral(" pt"));
     m_propertyFontSizeSpin->setFocusPolicy(Qt::NoFocus);

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -406,6 +406,49 @@ ShotWindow::ShotWindow(QImage frozenFrame,
         }
     });
     fontPanelLayout->addWidget(m_propertyFontList);
+
+    // 字号精确输入（最终点大小 = 20 + 文本宽度偏移）
+    m_propertyFontSizeSpin = new QSpinBox(m_propertyFontPanel);
+    m_propertyFontSizeSpin->setRange(8, 300);
+    m_propertyFontSizeSpin->setSingleStep(1);
+    m_propertyFontSizeSpin->setSuffix(QStringLiteral(" pt"));
+    m_propertyFontSizeSpin->setFocusPolicy(Qt::NoFocus);
+    m_propertyFontSizeSpin->setToolTip(MS_TR("Text font size in points"));
+    connect(m_propertyFontSizeSpin, &QSpinBox::valueChanged, this, [this](int value) {
+        setSelectedTextFontSize(value);
+    });
+    fontPanelLayout->addWidget(m_propertyFontSizeSpin);
+
+    auto *fontStyleLayout = new QHBoxLayout;
+    fontStyleLayout->setContentsMargins(0, 4, 0, 0);
+    fontStyleLayout->setSpacing(4);
+    m_propertyFontBoldButton = new QToolButton(m_propertyFontPanel);
+    m_propertyFontBoldButton->setCheckable(true);
+    m_propertyFontBoldButton->setText(QStringLiteral("B"));
+    m_propertyFontBoldButton->setToolTip(MS_TR("Bold"));
+    m_propertyFontBoldButton->setFocusPolicy(Qt::NoFocus);
+    QFont boldButtonFont = m_propertyFontBoldButton->font();
+    boldButtonFont.setBold(true);
+    m_propertyFontBoldButton->setFont(boldButtonFont);
+    connect(m_propertyFontBoldButton, &QToolButton::toggled, this, [this](bool checked) {
+        setSelectedTextBold(checked);
+    });
+    fontStyleLayout->addWidget(m_propertyFontBoldButton);
+    m_propertyFontItalicButton = new QToolButton(m_propertyFontPanel);
+    m_propertyFontItalicButton->setCheckable(true);
+    m_propertyFontItalicButton->setText(QStringLiteral("I"));
+    m_propertyFontItalicButton->setToolTip(MS_TR("Italic"));
+    m_propertyFontItalicButton->setFocusPolicy(Qt::NoFocus);
+    QFont italicButtonFont = m_propertyFontItalicButton->font();
+    italicButtonFont.setItalic(true);
+    m_propertyFontItalicButton->setFont(italicButtonFont);
+    connect(m_propertyFontItalicButton, &QToolButton::toggled, this, [this](bool checked) {
+        setSelectedTextItalic(checked);
+    });
+    fontStyleLayout->addWidget(m_propertyFontItalicButton);
+    fontStyleLayout->addStretch(1);
+    fontPanelLayout->addLayout(fontStyleLayout);
+
     m_propertyFontPanel->hide();
 
     initializeTransientPanels();

--- a/src/shot_window_state.cpp
+++ b/src/shot_window_state.cpp
@@ -49,6 +49,8 @@ void ShotWindow::loadAnnotationStateFromDisk()
     if (!state.textFontFamily.isEmpty()) {
         m_textFontFamily = state.textFontFamily;
     }
+    m_textWeight = state.textFontWeight;
+    m_textItalic = state.textItalic;
 }
 
 /// @brief 调度一次工具默认值的持久化写盘
@@ -106,6 +108,8 @@ void ShotWindow::flushAnnotationStateNow()
     state.highlighterStyle = m_highlighterStyle;
     state.numberStyle = m_numberStyle;
     state.textFontFamily = m_textFontFamily;
+    state.textFontWeight = m_textWeight;
+    state.textItalic = m_textItalic;
     state.textBackgroundColor = m_textBackgroundColor;
 
     // 写入失败仅记录日志,不影响交互;dirty 已清,等待下次任意修改再次尝试


### PR DESCRIPTION
## Summary

The text tool previously only offered wheel/slider size adjustment with a fixed DemiBold weight and no way to set an exact point size. This adds precise, user-friendly font control:

- **Exact point-size input**: the font panel gains a spin box (8-300 pt). The value equals `20 + width offset`, so it stays in sync with the existing width slider in both directions.
- **Bold / Italic toggles**: two checkable buttons in the font panel.
- **Font family list** already existed; it now applies directly to the live inline text editor font.

## Details

- `Annotation` gains `fontWeight` and `textItalic` fields; the default tool state tracks the same values (`m_textWeight` / `m_textItalic`).
- Rendering, text measurement (`textContentRect`) and the inline text editor all honor family, weight, italic and point size.
- `AnnotationState` persists `textFontWeight` and `textItalic` across sessions (annotation-state.json).

## UI

The text font panel now shows: font family list → point-size spin box → [B] [I] toggle row. Panel updates reflect the selected annotation or the active default.

## Testing

- Built on Linux (Qt 6.11); the affected translation units compile cleanly.
- Font size spin box ↔ width slider ↔ wheel stay consistent; bold/italic apply to both new text and edited annotations; style persists after restart.