### PR TITLE
fix(window-detection): harden hover window selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ packaging/aur/mark-shot-*/
 .doc/
 __pycache__/
 *.py[cod]
+
+# 内部进度台账，不纳入版本控制（避免暴露给用户/上游）
+docs/ITERATION-LOG.md
+
+# 便携版构建产物
+/portable/

--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ The right-side action toolbar includes an **Extensions** button. It reads user-d
 
 See [Configuration Reference](docs/configuration.md).
 
+### User Guide
+
+For everyday operation — the window hover-selection feature, annotation
+tools, startup tools, pinned windows, scrolling capture, headless CLI, and a
+feature testing checklist — see the
+[User Guide](docs/user-guide.md) ([中文](docs/user-guide.zh-CN.md)).
+
 ## Compilation & Installation
 
 ### Installation Guide

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -253,6 +253,12 @@ mark-shot --tray
 
 参见[配置参考](docs/configuration.zh-CN.md)。
 
+### 用户操作手册
+
+日常操作（窗口悬停框选、标注工具、启动工具、贴纸窗口、长截图、headless CLI
+以及功能自测清单）请参见[用户操作手册](docs/user-guide.zh-CN.md)
+（[English](docs/user-guide.md)）。
+
 ## 编译与安装
 
 ### 安装指南

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,343 @@
+# Mark Shot User Guide
+
+This manual covers day-to-day operation of Mark Shot, with a focus on the
+**window / component hover selection** feature (moving the mouse automatically
+tracks and highlights the window under the cursor; a click selects it), the
+annotation workflow, headless capture, and configuration.
+
+> The docs in this repository are authored in the community fork and mirrored
+> to the upstream and enterprise repositories. The enterprise edition adds an
+> extra section for its local MCP server.
+
+---
+
+## 1. Quick Start
+
+### 1.1 Launching
+
+Start a region-capture session:
+
+```bash
+mark-shot
+```
+
+Press a desktop hotkey (see § 8) or run from a terminal. A frozen full-screen
+overlay opens on the focused display. Move the mouse to draw a selection
+rectangle, then release to enter the annotation editor.
+
+### 1.2 Portable builds
+
+If you use a portable bundle (`mark-shot-upstream`, `mark-shot-community`,
+`mark-shot-enterprise`), launch it with the bundled launcher so that the
+bundled Qt libraries, plugins, and helper scripts are found:
+
+```bash
+portable/mark-shot-community/bin/run-mark-shot.sh
+```
+
+The launcher prepends its `bin/` directory to `PATH`, which is required for the
+window-detection helper scripts (`mark-shot-window-detection-*`) and OCR /
+upload helpers.
+
+---
+
+## 2. Window / Component Hover Selection
+
+Mark Shot can detect the windows of the current desktop before you pick a
+region. While the selection overlay is open, **moving the mouse highlights the
+window under the cursor** with a teal frame. **A plain left click (no drag)
+selects that whole window** as the capture region; you can then annotate, copy,
+pin, or save it directly.
+
+The highlighted windows come from a per-compositor detection script that runs
+before the overlay appears:
+
+| Desktop | Detection source | Notes |
+| :--- | :--- | :--- |
+| GNOME Wayland | bundled `mark-shot-scroll-helper@snemc.org` Shell extension over D-Bus | requires the extension to be enabled (see § 2.1) |
+| KDE Plasma Wayland | one-shot KWin scripting via `qdbus6` / `qdbus` + journalctl | requires a KWin session |
+| Hyprland | `hyprctl -j clients` | |
+| niri | `niri msg -j windows` + config parsing | |
+| X11 | in-process XCB enumeration of `_NET_CLIENT_LIST_STACKING` | no script needed |
+| Windows | in-process `EnumWindows` | no script needed |
+
+Only **top-level windows** are tracked. Individual widgets inside a window
+("components") are not exposed by Wayland compositors, so hover selection
+targets whole windows on every platform.
+
+### 2.1 GNOME Wayland: enable the helper extension
+
+```bash
+gnome-extensions enable mark-shot-scroll-helper@snemc.org
+```
+
+Verify the D-Bus helper answers:
+
+```bash
+gdbus call --session \
+  --dest org.gnome.Shell \
+  --object-path /org/gnome/Shell/Extensions/MarkShotScrollHelper \
+  --method org.gnome.Shell.Extensions.MarkShotScrollHelper.Version
+# -> ('5',)
+```
+
+If the call fails, log out and back in (or restart GNOME Shell on X11) and
+retry. Without the extension the GNOME helper script exits with an error and
+hover selection stays off (normal drag-selection still works).
+
+### 2.2 How to use it
+
+1. Trigger a capture (`mark-shot` or the desktop hotkey).
+2. Without pressing any mouse button, move the cursor over a window. A teal
+   frame outlines the window that would be selected.
+3. **Click once** (press and release without moving more than a few pixels) to
+   select that window. If windows overlap, the topmost window at the cursor
+   wins (z-order aware).
+4. Release enters the annotation editor with the window exactly framed.
+5. To make a **manual** region instead, simply drag a rectangle as usual — the
+   hover frame is ignored as soon as the drag exceeds the click threshold.
+
+The hover highlight is disabled while the Color Picker (`C`) or Ruler (`R`)
+startup tool is active, and remains available for Code Scanner (`Q`), display
+capture (`D`), and GIF / Video recording startup modes.
+
+### 2.3 Selecting windows on the correct monitor
+
+Window detection runs per capture target. On a multi-monitor setup, each
+frozen window receives only the windows intersecting its own geometry, so the
+hover frame matches what you see on that display.
+
+### 2.4 Enabling / disabling
+
+The feature is enabled by default (`windowDetection.enabled = true`). Toggle it
+in **Settings → Advanced → Window Detection Enabled**, or edit
+`~/.config/mark-shot/config.json`:
+
+```json
+{
+  "windowDetection": {
+    "enabled": true,
+    "command": "mark-shot-window-detection-gnome",
+    "timeoutMs": 1000,
+    "env": {}
+  }
+}
+```
+
+- `command`: the detection script. On GNOME / KDE / Hyprland / niri Wayland the
+  bundled `mark-shot-window-detection-*` script matching your session is chosen
+  automatically; on X11 and Windows the platform is enumerated in-process and
+  `command` may be left empty. **A user-supplied custom command (for example an
+  absolute path) is always respected.**
+- `timeoutMs`: maximum wait for the script (100–30000 ms, default 1000).
+- `env`: extra environment variables passed to the script. Per-compositor
+  tweaks (offsets) are documented in the script headers.
+
+### 2.5 Troubleshooting
+
+| Symptom | Check |
+| :--- | :--- |
+| No teal frame on GNOME Wayland | extension enabled? `gdbus` call above must return a version |
+| No teal frame on X11 / Windows | none — platform enumeration is built in; make sure the capture session is not using a startup pointer tool |
+| Hover frame picks the wrong (underneath) window | z-order data missing from a custom detection script; windows without `zOrder` are ranked as the bottom layer |
+| Capture starts slowly | the detection script runs before the overlay; raise `timeoutMs` only if the desktop is slow, or set `enabled:false` to skip it |
+| See diagnostics | run `mark-shot --debug --debug-log /tmp/mark-shot.log`; look for `window-detection` lines |
+
+---
+
+## 3. Region Selection & Startup Tools
+
+Before the region is committed you can use the startup overlay tools:
+
+| Hotkey | Tool | Behaviour |
+| :---: | :--- | :--- |
+| `C` | Color Picker | Sample a pixel; wheel resizes the loupe; left click opens a color panel (HEX / RGB / HSL / HSV / Qt formats); right click or `Esc` exits |
+| `R` | Ruler | Hover reads pixel coordinates; left-drag measures a rectangle with width, height, diagonal and area; right click or `Esc` exits |
+| `Q` | Code Scanner | Drag a region around a QR / barcode; the decoded result opens in a copyable window |
+| `D` | Display Capture | Captures all outputs, crops per display, shows hoverable thumbnails (copy / edit / save) |
+| `S` | Stop active GIF / video recording | stops the recording shown in the overlay |
+
+`Esc` cancels the session; right click (no startup tool) also cancels.
+
+---
+
+## 4. Annotation Tools
+
+After a region is selected (or a local image is opened) the editor opens with
+the annotation toolbar. Tools are switched with the number keys or the toolbar:
+
+| Hotkey | Tool | Description |
+| :---: | :--- | :--- |
+| `V` | Move / Pan | move the whole selection, pan a local image canvas |
+| `S` | Select | select, move, scale, rotate, delete existing annotations |
+| `P` | Pen | smooth freehand strokes |
+| `L` | Line | straight lines |
+| `H` | Highlighter | semi-transparent marker; freehand or straight line style |
+| `R` | Rectangle | box with `Stroke` / `Highlight` / `Invert` styles, rounded corners |
+| `E` | Ellipse | ellipse / circle |
+| `A` | Arrow | classic arrows (fletched, KDE, bidirectional) |
+| `T` | Text | rich text; wheel or sliders resize; diagonal handles scale both, side handles adjust wrap; exact pt size, font family, bold / italic in the font panel |
+| `N` | Number | sequential numbered markers (Arabic, alpha, roman, Chinese, …) |
+| `M` | Mosaic | acrylic frost blur to hide sensitive content |
+| `G` | Laser | temporary strokes that dissolve automatically |
+
+Drawing tips:
+
+- Hold `Ctrl` while drawing a rectangle / ellipse to constrain to a square /
+  circle.
+- Scroll the wheel while a tool is active to adjust stroke width, text size,
+  number scale, or mosaic block size (live preview).
+- Under `Select`, scroll to zoom the canvas and hold the middle button to pan;
+  double-tap `Ctrl` to reset.
+
+### 4.1 Editing an existing annotation
+
+Switch to **Select** (`S`). Click an annotation to show its handles:
+
+- drag inside to move;
+- drag corner / edge handles to resize;
+- drag the round handle above the top edge to rotate;
+- press `Delete` / `Backspace` to remove;
+- double-click text to edit it in place.
+
+The property panel (right side) edits the selected annotation: color, width,
+style, text font family / size / bold / italic. Multiple annotations can be
+selected by dragging a selection box under the `Select` tool; the group can
+then be moved, resized, rotated and deleted together.
+
+### 4.2 Actions
+
+| Shortcut | Action |
+| :--- | :--- |
+| `Ctrl+C` | copy to clipboard |
+| `Ctrl+S` / `Enter` | save (path template from settings) |
+| `Ctrl+P` | pin as a floating sticker window |
+| `Ctrl+U` | upload to the configured image host; URL is copied |
+| `Ctrl+Z` / `Ctrl+Y` | undo / redo |
+| `F` | toggle the capture scope (selection ↔ full screen) |
+
+### 4.3 Export frame
+
+Enable **Settings → Export → Mac-style frame** to add transparent padding,
+rounded corners, and a soft shadow to saved / copied / uploaded images.
+
+---
+
+## 5. Pinned Window Stickers
+
+| Gesture / Shortcut | Behaviour |
+| :--- | :--- |
+| left-drag | reposition the sticker |
+| wheel | scale proportionally |
+| double left click / `Esc` | close |
+| right click | context menu (rotate, zoom, always-on-top, copy text, translate, save, copy, close) |
+
+OCR text inside a pinned window is selectable and copyable (`Ctrl+C` /
+context menu). Translation (OpenAI-compatible endpoint) renders the translated
+text back onto the image at the original layout positions.
+
+---
+
+## 6. Scrolling Screenshot
+
+1. Select a region (or use the floating drag handle for very large regions).
+2. The overlay scrolls the target window; captured frames are stitched into a
+   long image.
+3. GNOME Wayland requires the Mark Shot Scroll Helper extension (§ 2.1).
+
+Scrolling capture is production-ready on niri and similar wlroots/Wayland
+compositors; on KDE, X11 and other stacks it is a test feature. If it fails,
+use normal screenshots or a custom extension command.
+
+---
+
+## 7. Headless Capture (CLI)
+
+Non-interactive capture writes a PNG and prints JSON:
+
+```bash
+# primary screen
+mark-shot --capture-to /tmp/shot.png
+
+# directory (timestamped file name)
+mark-shot --capture-to /tmp/shots/
+
+# region
+mark-shot --capture-to /tmp/r.png --region 0,0,1280,720
+
+# a specific display, with cursor
+mark-shot --capture-to /tmp/w.png --display DP-1 --include-cursor
+
+# several displays at once (one PNG each)
+mark-shot --capture-to /tmp/shots/ --display DP-1 --display DP-2
+
+# list outputs
+mark-shot --list-displays
+```
+
+All headless options are mutually exclusive with a positional image file.
+See the README for the full argument table.
+
+---
+
+## 8. Desktop Hotkeys & Tray
+
+Tray mode (`mark-shot --tray`) registers `Ctrl+Alt+S` for region capture and
+provides capture / recording / settings / quit menu entries. Desktop hotkeys:
+
+- **GNOME**: Settings → Keyboard → Shortcuts → Custom Shortcuts → bind to `mark-shot`.
+- **KDE**: custom shortcut bound to `mark-shot` (plus the KWin ScreenShot2
+  permission for exact KDE capture, see README).
+- **Hyprland**: `bind = SUPER SHIFT, S, exec, mark-shot` and `bind = , Print, exec, mark-shot`.
+- **niri**: `binds { Mod+Shift+S { spawn "mark-shot"; } }`.
+- **Sway / i3**: `bindsym Mod4+Shift+S exec mark-shot`.
+
+---
+
+## 9. Configuration & Backends
+
+- Config file: `~/.config/mark-shot/config.json` (Linux), created on first run.
+- Full reference: [Configuration](configuration.md).
+- Backends: Wayland (PipeWire portal / grim / wlroots screencopy), X11
+  (`QScreen::grabWindow`), Windows (native WGC). Recording prefers the
+  PipeWire portal and falls back automatically.
+
+Optional helpers:
+
+```bash
+# OCR (RapidOCR / Tesseract)
+python3 -m venv ~/.local/share/mark-shot/ocr-venv
+~/.local/share/mark-shot/ocr-venv/bin/pip install -U pip rapidocr onnxruntime
+
+# Code scan (zxing-cpp)
+python3 -m venv ~/.local/share/mark-shot/code-scan-venv
+~/.local/share/mark-shot/code-scan-venv/bin/pip install -U pip zxing-cpp pillow
+```
+
+---
+
+## 10. Feature Testing Checklist
+
+Use this to verify a build end-to-end:
+
+1. **Launch** — `run-mark-shot.sh` opens the frozen overlay.
+2. **Window hover** — move the mouse over a window: teal frame follows; single
+   click selects the window; overlapping windows pick the topmost one.
+3. **Manual region** — drag a rectangle; release; editor opens.
+4. **Annotate** — draw with each tool (Pen, Line, Rectangle, Ellipse, Arrow,
+   Highlighter, Text, Number, Mosaic, Magnifier, Laser); undo/redo; Select to
+   move/resize/rotate/delete; double-click a text to edit.
+5. **Copy / Save / Pin / Upload** — `Ctrl+C`, `Ctrl+S`, `Ctrl+P`, `Ctrl+U`.
+6. **Startup tools** — `C` color picker, `R` ruler, `Q` code scan, `D` display
+   capture.
+7. **Headless** — `--capture-to`, `--region`, `--display`, `--list-displays`.
+8. **Tray + hotkey** — `mark-shot --tray`, press `Ctrl+Alt+S`.
+9. **Portable specifics** — bundle finds its own Qt libs/plugins/scripts.
+
+---
+
+## 11. Feedback
+
+Report issues with `gh issue create` using the bundled
+[issue submission guide](../../.doc/submit-issue-via-gh.md). Attach a debug log
+captured with `mark-shot --debug --debug-log /tmp/mark-shot.log`.

--- a/docs/user-guide.zh-CN.md
+++ b/docs/user-guide.zh-CN.md
@@ -1,0 +1,319 @@
+# Mark Shot 用户操作手册
+
+本文档介绍 Mark Shot 的日常使用，重点覆盖**指定窗口/组件悬停框选截图**功能
+（鼠标移动时自动跟踪并高亮光标下方的窗口，单击即可选中该窗口）、标注工作流、
+headless 截图与配置。
+
+> 本仓库的文档在社区版 fork 中编写，并镜像到上游与商业版仓库。商业版额外包含
+> 针对其本地 MCP server 的专门章节。
+
+---
+
+## 1. 快速开始
+
+### 1.1 启动
+
+开始一次区域截图会话：
+
+```bash
+mark-shot
+```
+
+按下桌面快捷键（见 § 8）或在终端运行。焦点显示器上会打开一个冻结的全屏覆盖层。
+移动鼠标拉出选择矩形，松开后进入标注编辑器。
+
+### 1.2 便携版应用
+
+如果使用便携版（`mark-shot-upstream` / `mark-shot-community` /
+`mark-shot-enterprise`），请用自带的启动脚本启动，以便找到内置的 Qt 库、
+插件与辅助脚本：
+
+```bash
+portable/mark-shot-community/bin/run-mark-shot.sh
+```
+
+启动脚本会把其 `bin/` 目录加入 `PATH`，这是窗口检测脚本
+（`mark-shot-window-detection-*`）以及 OCR / 上传辅助脚本能够被找到的必要条件。
+
+---
+
+## 2. 窗口 / 组件悬停框选
+
+Mark Shot 在选区开始前会检测当前桌面的窗口。覆盖层打开后，**移动鼠标即可在
+光标所在窗口上高亮显示青色边框**；**直接单击（不拖动）即可选中整个窗口**作为
+截图区域，随后可直接标注、复制、钉住或保存。
+
+高亮的窗口来自按合成器区分的检测脚本，它们在覆盖层出现前运行：
+
+| 桌面 | 检测来源 | 说明 |
+| :--- | :--- | :--- |
+| GNOME Wayland | 内置 `mark-shot-scroll-helper@snemc.org` Shell 扩展（D-Bus） | 需要启用扩展（见 § 2.1） |
+| KDE Plasma Wayland | 通过 `qdbus6` / `qdbus` + journalctl 的一次性 KWin 脚本 | 需要 KWin 会话 |
+| Hyprland | `hyprctl -j clients` | |
+| niri | `niri msg -j windows` + 配置解析 | |
+| X11 | 进程内 XCB 枚举 `_NET_CLIENT_LIST_STACKING` | 无需脚本 |
+| Windows | 进程内 `EnumWindows` | 无需脚本 |
+
+只跟踪**顶层窗口**。窗口内部的单个控件（“组件”）在 Wayland 合成器中不暴露，
+因此所有平台上的悬停框选都针对整个窗口。
+
+### 2.1 GNOME Wayland：启用辅助扩展
+
+```bash
+gnome-extensions enable mark-shot-scroll-helper@snemc.org
+```
+
+验证 D-Bus 辅助接口可用：
+
+```bash
+gdbus call --session \
+  --dest org.gnome.Shell \
+  --object-path /org/gnome/Shell/Extensions/MarkShotScrollHelper \
+  --method org.gnome.Shell.Extensions.MarkShotScrollHelper.Version
+# -> ('5',)
+```
+
+如果调用失败，请注销后重新登录（X11 上重启 GNOME Shell）再试。没有扩展时
+GNOME 检测脚本会报错退出，悬停框选保持关闭（普通拖拽框选不受影响）。
+
+### 2.2 使用方法
+
+1. 触发截图（`mark-shot` 或桌面快捷键）。
+2. 不按任何鼠标键，把光标移到某个窗口上，出现青色边框标示将被选中的窗口。
+3. **单击一次**（按下并松开、位移不超过几像素）即可选中该窗口。窗口重叠时，
+   优先选中光标下最顶层的窗口（按 z 序）。
+4. 松开后进入标注编辑器，窗口刚好被精确框选。
+5. 如果只想做**手动**框选，正常拖动矩形即可——一旦拖动超过单击阈值，悬停框
+   即被忽略。
+
+当取色器（`C`）或标尺（`R`）启动工具激活时，悬停高亮被禁用；二维码扫描（`Q`）、
+显示器快照（`D`）以及 GIF / 视频录制的启动模式仍可使用。
+
+### 2.3 多显示器下正确选择窗口
+
+窗口检测按每个捕获目标分别执行。在多显示器环境，每个冻结窗口只接收与其自身
+几何相交的窗口，因此悬停框与你在该显示器上看到的内容一致。
+
+### 2.4 启用 / 禁用
+
+该功能默认开启（`windowDetection.enabled = true`）。可在
+**设置 → 高级 → 窗口检测已启用** 中切换，或编辑 `~/.config/mark-shot/config.json`：
+
+```json
+{
+  "windowDetection": {
+    "enabled": true,
+    "command": "mark-shot-window-detection-gnome",
+    "timeoutMs": 1000,
+    "env": {}
+  }
+}
+```
+
+- `command`：检测脚本。GNOME / KDE / Hyprland / niri Wayland 下会自动选择与
+  当前会话匹配的内置 `mark-shot-window-detection-*` 脚本；X11 与 Windows 在
+  进程内枚举平台，`command` 可留空。**用户自定义命令（例如绝对路径）始终会被
+  尊重，不会被覆盖。**
+- `timeoutMs`：等待脚本的最长时间（100–30000 ms，默认 1000）。
+- `env`：传给脚本的额外环境变量。各合成器的微调（偏移量等）见脚本头注释。
+
+### 2.5 故障排查
+
+| 现象 | 检查项 |
+| :--- | :--- |
+| GNOME Wayland 下没有青色框 | 扩展是否启用？上面 `gdbus` 调用必须返回版本号 |
+| X11 / Windows 下没有青色框 | 平台枚举是内置的，无需操作；确认没有启用取色器 / 标尺启动工具 |
+| 悬停框选到了错误的（下层）窗口 | 自定义检测脚本缺少 z 序数据；没有 `zOrder` 的窗口按最底层处理 |
+| 截图启动变慢 | 检测脚本在覆盖层之前运行；只有桌面响应慢才需要调大 `timeoutMs`，或设 `enabled:false` 跳过 |
+| 查看诊断 | 运行 `mark-shot --debug --debug-log /tmp/mark-shot.log`，查找 `window-detection` 日志行 |
+
+---
+
+## 3. 区域选择与启动工具
+
+提交区域之前可使用以下启动工具：
+
+| 快捷键 | 工具 | 行为 |
+| :---: | :--- | :--- |
+| `C` | 取色器 | 采样像素；滚轮缩放放大镜；左键打开颜色面板（HEX / RGB / HSL / HSV / Qt 格式）；右键或 `Esc` 退出 |
+| `R` | 标尺 | 悬停读取像素坐标；左键拖动测量矩形（宽、高、对角线、面积）；右键或 `Esc` 退出 |
+| `Q` | 二维码扫描 | 圈选二维码 / 条形码区域；解码结果在可复制窗口中打开 |
+| `D` | 显示器快照 | 捕获全部输出、按显示器裁剪并显示可悬停缩略图（复制 / 编辑 / 保存） |
+| `S` | 停止录制 | 停止覆盖层中显示的 GIF / 视频录制 |
+
+`Esc` 取消会话；右键（无启动工具时）同样取消。
+
+---
+
+## 4. 标注工具
+
+选中区域（或打开本地图片）后进入编辑器，显示标注工具栏。工具可用数字键或
+工具栏切换：
+
+| 快捷键 | 工具 | 说明 |
+| :---: | :--- | :--- |
+| `V` | 移动 / 平移 | 移动整个选区；本地图片模式下平移画布 |
+| `S` | 选择 | 选择、移动、缩放、旋转、删除已有标注 |
+| `P` | 画笔 | 平滑手绘笔迹 |
+| `L` | 直线 | 直线 |
+| `H` | 荧光笔 | 半透明标记；支持手绘或直线样式 |
+| `R` | 矩形 | 支持 `描边` / `高亮` / `反色` 三种样式与圆角 |
+| `E` | 椭圆 | 椭圆 / 正圆 |
+| `A` | 箭头 | 经典箭头（实心、KDE、双向） |
+| `T` | 文字 | 富文本；滚轮或滑块调节大小；对角手柄等比缩放、边侧手柄调节换行宽度；字体面板支持精确字号、字体族、粗体 / 斜体 |
+| `N` | 序号 | 自动递增的编号标记（阿拉伯、字母、罗马、中文等） |
+| `M` | 马赛克 | 亚克力磨砂模糊，用于遮挡敏感信息 |
+| `G` | 激光 | 自动消散的临时笔迹 |
+
+绘制技巧：
+
+- 绘制矩形 / 椭圆时按住 `Ctrl` 约束为正圆 / 正方形。
+- 工具激活时滚动滚轮可动态调节描边宽度、文字大小、编号缩放或马赛克块大小
+  （实时预览）。
+- `选择` 工具下滚动滚轮缩放画布，按住中键平移；双击 `Ctrl` 重置。
+
+### 4.1 编辑已有标注
+
+切换到**选择**（`S`）。点击标注显示控制手柄：
+
+- 内部拖动：移动；
+- 拖动角 / 边手柄：缩放；
+- 拖动上边缘外侧的圆形手柄：旋转；
+- 按 `Delete` / `Backspace`：删除；
+- 双击文字：就地编辑。
+
+右侧属性面板编辑选中标注：颜色、宽度、样式、文字字体 / 字号 / 粗体 / 斜体。
+`选择` 工具下拖出选框可多选，多选后可整体移动、缩放、旋转、删除。
+
+### 4.2 动作
+
+| 快捷键 | 动作 |
+| :--- | :--- |
+| `Ctrl+C` | 复制到剪贴板 |
+| `Ctrl+S` / `Enter` | 保存（路径模板来自设置） |
+| `Ctrl+P` | 钉住为悬浮贴纸窗口 |
+| `Ctrl+U` | 上传到配置的图床；返回的 URL 自动复制 |
+| `Ctrl+Z` / `Ctrl+Y` | 撤销 / 重做 |
+| `F` | 切换捕获范围（选区 ↔ 全屏） |
+
+### 4.3 导出相框
+
+开启 **设置 → 导出 → 苹果风格相框** 后，保存 / 复制 / 上传的图片会带上透明
+内边距、圆角与柔和阴影。
+
+---
+
+## 5. 钉住的贴纸窗口
+
+| 手势 / 快捷键 | 行为 |
+| :--- | :--- |
+| 左键拖动 | 移动贴纸 |
+| 滚轮 | 等比缩放 |
+| 双击左键 / `Esc` | 关闭 |
+| 右键 | 上下文菜单（旋转、缩放、置顶、复制文字、翻译、保存、复制、关闭） |
+
+贴纸窗口内的 OCR 文字可直接选择复制（`Ctrl+C` / 右键菜单）。翻译
+（OpenAI 兼容接口）会把译文按原布局位置渲染回图片上。
+
+---
+
+## 6. 长截图（滚动截图）
+
+1. 选择区域（超大区域会显示浮动拖拽手柄）。
+2. 覆盖层滚动目标窗口，捕获的帧被拼接为长图。
+3. GNOME Wayland 需要 Mark Shot Scroll Helper 扩展（§ 2.1）。
+
+滚动截图在 niri 及类似的 wlroots/Wayland 合成器上已可稳定使用；在 KDE、X11
+等环境属于测试特性。失败时可改用普通截图或自定义扩展命令。
+
+---
+
+## 7. Headless 截图（CLI）
+
+非交互截图会写入 PNG 并输出 JSON：
+
+```bash
+# 主屏
+mark-shot --capture-to /tmp/shot.png
+
+# 目录（自动生成时间戳文件名）
+mark-shot --capture-to /tmp/shots/
+
+# 区域
+mark-shot --capture-to /tmp/r.png --region 0,0,1280,720
+
+# 指定显示器，包含鼠标
+mark-shot --capture-to /tmp/w.png --display DP-1 --include-cursor
+
+# 一次捕获多个显示器（每个一张 PNG）
+mark-shot --capture-to /tmp/shots/ --display DP-1 --display DP-2
+
+# 列出输出
+mark-shot --list-displays
+```
+
+所有 headless 选项与位置参数（图片文件）互斥。完整参数表见 README。
+
+---
+
+## 8. 桌面快捷键与托盘
+
+托盘模式（`mark-shot --tray`）默认注册 `Ctrl+Alt+S` 区域截图，并提供捕获 /
+录制 / 设置 / 退出菜单。桌面快捷键配置：
+
+- **GNOME**：设置 → 键盘 → 快捷键 → 自定义快捷键，绑定到 `mark-shot`。
+- **KDE**：自定义快捷键绑定 `mark-shot`（精确 KDE 捕获还需 KWin ScreenShot2
+  权限，见 README）。
+- **Hyprland**：`bind = SUPER SHIFT, S, exec, mark-shot` 与
+  `bind = , Print, exec, mark-shot`。
+- **niri**：`binds { Mod+Shift+S { spawn "mark-shot"; } }`。
+- **Sway / i3**：`bindsym Mod4+Shift+S exec mark-shot`。
+
+---
+
+## 9. 配置与后端
+
+- 配置文件：`~/.config/mark-shot/config.json`（Linux），首次运行自动创建。
+- 完整参考：[配置文档](configuration.zh-CN.md)。
+- 后端：Wayland（PipeWire portal / grim / wlroots screencopy）、X11
+  （`QScreen::grabWindow`）、Windows（原生 WGC）。录制优先使用 PipeWire
+  portal，失败时自动回退。
+
+可选辅助：
+
+```bash
+# OCR（RapidOCR / Tesseract）
+python3 -m venv ~/.local/share/mark-shot/ocr-venv
+~/.local/share/mark-shot/ocr-venv/bin/pip install -U pip rapidocr onnxruntime
+
+# 二维码扫描（zxing-cpp）
+python3 -m venv ~/.local/share/mark-shot/code-scan-venv
+~/.local/share/mark-shot/code-scan-venv/bin/pip install -U pip zxing-cpp pillow
+```
+
+---
+
+## 10. 功能自测清单
+
+按以下步骤端到端验证一个构建：
+
+1. **启动** — `run-mark-shot.sh` 打开冻结覆盖层。
+2. **窗口悬停** — 鼠标移到窗口上：青色框跟随；单击选中窗口；重叠窗口选中
+   最顶层。
+3. **手动框选** — 拖动矩形；松开进入编辑器。
+4. **标注** — 逐个试用工具（画笔、直线、矩形、椭圆、箭头、荧光笔、文字、序号、
+   马赛克、放大镜、激光）；撤销 / 重做；选择工具移动 / 缩放 / 旋转 / 删除；
+   双击文字编辑。
+5. **复制 / 保存 / 钉住 / 上传** — `Ctrl+C`、`Ctrl+S`、`Ctrl+P`、`Ctrl+U`。
+6. **启动工具** — `C` 取色器、`R` 标尺、`Q` 扫码、`D` 显示器快照。
+7. **Headless** — `--capture-to`、`--region`、`--display`、`--list-displays`。
+8. **托盘与快捷键** — `mark-shot --tray`，按 `Ctrl+Alt+S`。
+9. **便携版细节** — 包内自带 Qt 库 / 插件 / 脚本可被找到。
+
+---
+
+## 11. 反馈
+
+使用内置的[问题提交指南](../../.doc/submit-issue-via-gh.md)，通过 `gh issue
+create` 提交问题，并附上 `mark-shot --debug --debug-log /tmp/mark-shot.log`
+抓取的调试日志。

--- a/src/shot_window_input.cpp
+++ b/src/shot_window_input.cpp
@@ -53,14 +53,21 @@ void ShotWindow::mouseMoveEvent(QMouseEvent *event)
                 continue;
             }
 
+            // 只要存在任一窗口带 zOrder,本次命中判定统一按 z 序比较,
+            // 缺少 zOrder 的窗口按最底层处理,避免混用面积/深度两套规则。
+            if (info.zOrder.has_value()) {
+                useZOrder = true;
+            }
+
             if (!best.has_value()) {
-                useZOrder = info.zOrder.has_value();
                 best = info;
                 continue;
             }
 
             if (useZOrder) {
-                if (info.zOrder > best->zOrder) {
+                const int infoZ = info.zOrder.value_or(-1);
+                const int bestZ = best->zOrder.value_or(-1);
+                if (infoZ > bestZ) {
                     best = info;
                 }
             } else {

--- a/src/window_detection.cpp
+++ b/src/window_detection.cpp
@@ -125,7 +125,9 @@ QString detectWaylandSessionType()
         return QStringLiteral("niri");
     }
 
-    return QStringLiteral("niri");
+    // 未知的 Wayland 合成器(如 sway/river 等)不猜测内置脚本,
+    // 避免在错误的桌面环境上执行不兼容的检测脚本。
+    return {};
 }
 
 /// @brief Returns the appropriate window detection command for the current desktop environment.
@@ -195,7 +197,8 @@ constexpr int kDefaultWindowDetectionTimeoutMs = 1000;
 /// @brief Minimum allowed timeout value in milliseconds for window detection.
 constexpr int kMinWindowDetectionTimeoutMs = 100;
 /// @brief Maximum allowed timeout value in milliseconds for window detection.
-constexpr int kMaxWindowDetectionTimeoutMs = 10000;
+/// 与设置面板 spin 上限(30000ms)保持一致,避免面板值与实际生效值不一致。
+constexpr int kMaxWindowDetectionTimeoutMs = 30000;
 
 /// @brief Configuration settings for the external window detection process.
 struct WindowDetectionConfig {
@@ -509,17 +512,26 @@ std::optional<bool> configuredWindowDetectionEnabled(const QJsonObject &root)
 /// @brief 判断已配置的窗口检测命令是否匹配当前桌面环境。
 /// @param command 用户配置中的窗口检测命令。
 /// @return 匹配当前桌面环境时返回 true，否则返回 false。
+///
+/// 行为约定:
+/// - 非 Wayland 会话(如 X11)与 Windows:尊重用户配置,空命令交由平台枚举回退。
+/// - Wayland 会话下内置默认脚本(mark-shot-window-detection-*)仅在面向其他
+///   合成器时自动纠正为当前会话对应的脚本;用户自定义命令(非内置脚本名,
+///   例如带路径的脚本)一律保留,不再被静默覆盖。
 bool commandMatchesEnvironment(const QString &command)
 {
 #if defined(Q_OS_WIN)
-    return command.isEmpty();
+    return true;
 #else
     const QString sessionType = detectWaylandSessionType();
     if (sessionType.isEmpty()) {
-        return command.isEmpty();
+        return true;
     }
     if (command.isEmpty()) {
         return false;
+    }
+    if (!command.startsWith(QStringLiteral("mark-shot-window-detection-"))) {
+        return true;
     }
     return command.contains(sessionType);
 #endif


### PR DESCRIPTION
## Summary

Hardens the window hover-selection feature used before region selection
(moving the mouse highlights the window under the cursor; a single click
selects it).

## Changes

- **`window_detection.cpp` — `commandMatchesEnvironment`:** user-supplied
  custom detection commands (e.g. absolute paths) are now always respected;
  only the bundled `mark-shot-window-detection-*` default scripts are
  auto-corrected for the current compositor. Previously any command that did
  not contain the session keyword was silently replaced (and non-empty custom
  commands were cleared on X11).
- **`window_detection.cpp` — `detectWaylandSessionType`:** unknown Wayland
  compositors (sway, river, ...) no longer fall back to the niri detection
  script, which always failed and polluted logs; they now use the platform
  fallback instead.
- **`shot_window_input.cpp` — hover hit selection:** if any window carries a
  `zOrder`, ranking is done consistently by z-order and windows without
  `zOrder` are treated as the bottom layer. Previously the comparison mode
  depended on which window happened to be hit first, mixing area-based and
  depth-based ranking.
- **`window_detection.cpp`:** the timeout clamp now matches the settings UI
  range (100–30000 ms).

## Testing

- All 38 tests pass (ctest).
- Hover selection verified on GNOME Wayland with the bundled
  `mark-shot-scroll-helper@snemc.org` extension (D-Bus `Version` → `5`).