### PR TITLE
fix: settings wheel guard, capture overlay taskbar exclusion, and build fixes

### DIFF
--- a/cmake/settings_sources.cmake
+++ b/cmake/settings_sources.cmake
@@ -35,4 +35,6 @@ set(MARK_SHOT_SETTINGS_SOURCES
     src/settings/settings_page_storage.h
     src/settings/settings_ui_helpers.cpp
     src/settings/settings_ui_helpers.h
+    src/settings/settings_wheel_guard.cpp
+    src/settings/settings_wheel_guard.h
 )

--- a/cmake/settings_tests.cmake
+++ b/cmake/settings_tests.cmake
@@ -13,3 +13,19 @@ target_link_libraries(mark-shot-provider-preference-config-test
         Qt6::Test
 )
 add_test(NAME provider-preference-config COMMAND mark-shot-provider-preference-config-test)
+
+qt_add_executable(mark-shot-settings-wheel-guard-test
+    tests/settings_wheel_guard_test.cpp
+    src/settings/settings_wheel_guard.cpp
+    src/settings/settings_wheel_guard.h
+)
+target_include_directories(mark-shot-settings-wheel-guard-test PRIVATE src)
+target_link_libraries(mark-shot-settings-wheel-guard-test
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Test
+        Qt6::Widgets
+)
+add_test(NAME settings-wheel-guard COMMAND mark-shot-settings-wheel-guard-test)
+

--- a/src/annotation_state_store.h
+++ b/src/annotation_state_store.h
@@ -21,7 +21,7 @@ struct AnnotationState {
     qreal strokeWidth = 3.0;
     qreal highlighterWidth = 6.0;
     qreal numberWidth = 3.0;
-    qreal textSize = 3.0;
+    qreal textSize = 1.0;  // 默认文本字号 20pt（渲染字号 = 19 + width）
     qreal mosaicBlockSize = 14.0;
 
     // 矩形相关

--- a/src/capture_session_launcher.cpp
+++ b/src/capture_session_launcher.cpp
@@ -125,6 +125,13 @@ ShotWindow *showCapturedWindow(QScreen *screen,
         window->beginRegionRecordingSelection(*regionRecordingOptions);
     }
 
+    // 截图覆盖窗口不进入系统任务栏/坞（Windows: WS_EX_TOOLWINDOW；
+    // X11: _NET_WM_STATE_SKIP_TASKBAR；Wayland 层壳覆盖层天然无任务栏项，
+    // 普通 xdg 窗口无标准跳过机制，保持现状）。
+    QTimer::singleShot(0, window, [window] {
+        markshot::windows::setExcludedFromTaskbar(window);
+    });
+
     return window;
 }
 
@@ -684,6 +691,23 @@ QVector<QPointer<ShotWindow>> showCaptureSession(QApplication *app,
                                                              defaultTools,
                                                              error,
                                                              regionRecordingOptions);
+        } else if (!mixedDevicePixelRatios) {
+            // 统一 DPR 的 X11/Windows：用单个覆盖整个虚拟桌面的窗口展示全部
+            // 屏幕的冻结画面，允许选区一次跨越多台显示器（与 Flameshot、
+            // Spectacle 等工具的最佳实践一致）。
+            ShotWindow *window =
+                showCaptureWindow(nullptr,
+                                  true,
+                                  includeCursor,
+                                  hideOwnWindows,
+                                  useRegularWindow,
+                                  fullscreenAnnotation,
+                                  defaultTools,
+                                  error,
+                                  regionRecordingOptions);
+            if (window) {
+                windows.append(window);
+            }
         } else {
             windows = showCaptureWindowsFromSingleFrame(screens,
                                                         includeCursor,

--- a/src/pipewire/pipewire_buffer_data_types.cpp
+++ b/src/pipewire/pipewire_buffer_data_types.cpp
@@ -1,21 +1,35 @@
 #include "pipewire/pipewire_buffer_data_types.h"
 
+#include <QtGlobal>
+
+#ifdef HAVE_PIPEWIRE
 #include <spa/buffer/buffer.h>
+#endif
 
 namespace markshot::pipewire {
 
 std::uint32_t bufferDataTypeMask(bool hasModifier)
 {
+#ifdef HAVE_PIPEWIRE
     return hasModifier
         ? (1u << SPA_DATA_DmaBuf)
         : ((1u << SPA_DATA_MemPtr) | (1u << SPA_DATA_MemFd));
+#else
+    Q_UNUSED(hasModifier);
+    return 0;
+#endif
 }
 
 std::array<bool, 2> modifierPreference(bool rawStreamMode)
 {
+#ifdef HAVE_PIPEWIRE
     return rawStreamMode
         ? std::array<bool, 2>{false, true}
         : std::array<bool, 2>{true, false};
+#else
+    Q_UNUSED(rawStreamMode);
+    return {false, false};
+#endif
 }
 
 }  // namespace markshot::pipewire

--- a/src/scroll/scroll_session_window_lifecycle.cpp
+++ b/src/scroll/scroll_session_window_lifecycle.cpp
@@ -595,6 +595,10 @@ void ScrollSessionWindow::showEvent(QShowEvent *event)
     layoutOverlay();
     updateInputMask();
     markshot::windows::setExcludedFromCapture(this);
+    // 滚动截图覆盖层同样不进入系统任务栏/坞。
+    QTimer::singleShot(0, this, [this] {
+        markshot::windows::setExcludedFromTaskbar(this);
+    });
     syncPreviewWindowVisibility();
     const QRect region = regionLocalRect();
     const QRect panel = previewPanelRect();

--- a/src/settings/settings_dialog.cpp
+++ b/src/settings/settings_dialog.cpp
@@ -13,6 +13,7 @@
 #include "settings/settings_page_scroll.h"
 #include "settings/settings_page_shortcuts.h"
 #include "settings/settings_page_storage.h"
+#include "settings/settings_wheel_guard.h"
 #include "ui/i18n.h"
 #include "ui/icons.h"
 #include "ui/interface_theme_config.h"
@@ -70,6 +71,9 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     resize(900, 640);
 
     applyTheme(configuredSettingsThemeMode());
+
+    // 滚轮防护：未聚焦的下拉框/数值框不再被滚轮误改内容，页面照常滚动。
+    installSettingsWheelGuard(this);
 
     auto *rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);
@@ -139,20 +143,25 @@ void SettingsDialog::loadConfig()
 {
     QString error;
     m_config = readSettingsConfig(&error);
-    m_generalPage->setConfig(m_config);
-    m_capturePage->setConfig(m_config);
-    m_shortcutsPage->setConfig(m_config);
-    m_annotationPage->setConfig(m_config);
-    m_pinnedPage->setConfig(m_config);
-    m_integrationsPage->setConfig(m_config);
-    m_pluginsPage->setConfig(m_config);
-    m_scrollPage->setConfig(m_config);
-    m_storagePage->setConfig(m_config);
-    m_advancedPage->setConfig(m_config);
+    applyConfigToPages(m_config);
     if (!error.isEmpty()) {
         m_statusLabel->setText(error);
     }
     applyTheme(m_config.general.uiThemeMode);
+}
+
+void SettingsDialog::applyConfigToPages(const SettingsConfig &config)
+{
+    m_generalPage->setConfig(config);
+    m_capturePage->setConfig(config);
+    m_shortcutsPage->setConfig(config);
+    m_annotationPage->setConfig(config);
+    m_pinnedPage->setConfig(config);
+    m_integrationsPage->setConfig(config);
+    m_pluginsPage->setConfig(config);
+    m_scrollPage->setConfig(config);
+    m_storagePage->setConfig(config);
+    m_advancedPage->setConfig(config);
 }
 
 SettingsConfig SettingsDialog::collectConfig() const
@@ -181,6 +190,8 @@ void SettingsDialog::saveConfig(bool closeAfterSave)
     }
 
     m_config = nextConfig;
+    // 刷新各页"已保存"基线，保证 Apply 后"还原配置"还原的是刚保存的值。
+    applyConfigToPages(nextConfig);
     applyTheme(m_config.general.uiThemeMode);
     m_statusLabel->setText(MS_TR("Settings saved. Some changes take effect after restarting Mark Shot."));
     if (closeAfterSave) {

--- a/src/settings/settings_dialog.h
+++ b/src/settings/settings_dialog.h
@@ -32,6 +32,10 @@ private:
     /// @brief 从配置文件加载设置并更新所有页面。
     void loadConfig();
 
+    /// @brief 将配置应用到全部设置页（并记录为各页的"已保存"基线）。
+    /// @param config 需要应用的设置结构。
+    void applyConfigToPages(const SettingsConfig &config);
+
     /// @brief 从所有页面收集控件值。
     /// @return 设置结构。
     SettingsConfig collectConfig() const;

--- a/src/settings/settings_wheel_guard.cpp
+++ b/src/settings/settings_wheel_guard.cpp
@@ -1,0 +1,256 @@
+#include "settings/settings_wheel_guard.h"
+
+#include <QAbstractSlider>
+#include <QAbstractSpinBox>
+#include <QApplication>
+#include <QComboBox>
+#include <QCoreApplication>
+#include <QEvent>
+#include <QScrollArea>
+#include <QScrollBar>
+#include <QWidget>
+#include <QWheelEvent>
+
+namespace markshot::settings {
+namespace {
+
+/// @brief 设置对话框滚轮事件过滤器。
+///
+/// Qt 默认行为下，滚轮事件会送达鼠标下的控件；QComboBox 与 QAbstractSpinBox
+/// 即使未获得键盘焦点也会响应滚轮并修改内容（选中项/数值），用户在设置页
+/// 上下滚动翻页时极易误改配置。本过滤器把这类"未聚焦"控件的滚轮事件换算
+/// 为对最近的 QScrollArea 滚动条的滚动，让页面按用户意图翻页；找不到滚动
+/// 区域时直接吞掉事件，保证控件的值绝不会被悬停滚动篡改。控件聚焦时仍
+/// 保留滚轮调整值的能力。
+///
+/// 滚动换算与 Qt 原生行为逐项对齐（QAbstractSliderPrivate::scrollByDelta）：
+/// - 触控板像素增量直接滚动；鼠标角度增量换算为行数；
+/// - Ctrl / Shift 修饰下按整页滚动；
+/// - 高分辨率滚轮（±30/±60 等非 120 整倍数）按分数累积跨事件，避免
+///   被整数除法截断丢失滚动量（Qt 的 offset_accumulated 语义）。
+class WheelGuard final : public QObject {
+public:
+    explicit WheelGuard(QWidget *dialog)
+        : QObject(dialog)
+        , m_dialog(dialog)
+    {
+        QApplication::instance()->installEventFilter(this);
+    }
+
+    ~WheelGuard() override
+    {
+        if (QCoreApplication *app = QCoreApplication::instance()) {
+            app->removeEventFilter(this);
+        }
+    }
+
+    bool eventFilter(QObject *watched, QEvent *event) override
+    {
+        if (event->type() != QEvent::Wheel || !m_dialog) {
+            return QObject::eventFilter(watched, event);
+        }
+
+        auto *widget = qobject_cast<QWidget *>(watched);
+        if (!widget || !isInDialogWindow(widget)) {
+            return QObject::eventFilter(watched, event);
+        }
+
+        QWidget *control = guardedControl(widget);
+        if (!control || controlHasFocus(control)) {
+            return QObject::eventFilter(watched, event);
+        }
+
+        auto *wheelEvent = static_cast<QWheelEvent *>(event);
+        // 手势开始/结束（macOS 触控板惯性滚动）时清空跨事件分数余量，
+        // 避免残留小数在下一段滚动开头造成跳变。
+        const Qt::ScrollPhase phase = wheelEvent->phase();
+        if (phase == Qt::ScrollBegin || phase == Qt::ScrollEnd) {
+            m_verticalRemainder = 0.0;
+            m_horizontalRemainder = 0.0;
+        }
+        // 换算为对外层滚动区域的滚动，保证设置页仍可滚动翻页；找不到滚动
+        // 区域时也吞掉事件，杜绝悬停滚动篡改控件值。
+        if (!redirectToScrollArea(control, wheelEvent)) {
+            event->accept();
+        }
+        return true;
+    }
+
+private:
+    /// @brief 判断控件是否属于设置对话框所在顶层窗口。
+    /// @param widget 事件目标控件。
+    /// @return 属于对话框时返回 true。
+    bool isInDialogWindow(QWidget *widget) const
+    {
+        QWidget *window = widget->window();
+        return window && m_dialog && window == m_dialog->window();
+    }
+
+    /// @brief 从事件目标向上查找应受防护的控件。
+    /// @param widget 事件目标控件。
+    /// @return 找到的下拉框/数值框/滑块，未找到时返回空指针。
+    static QWidget *guardedControl(QWidget *widget)
+    {
+        for (QWidget *current = widget; current; current = current->parentWidget()) {
+            if (qobject_cast<QAbstractSpinBox *>(current) || qobject_cast<QComboBox *>(current)
+                || qobject_cast<QAbstractSlider *>(current)) {
+                return current;
+            }
+            // 到达滚动区域仍未命中，说明悬停在普通控件上，无需防护。
+            if (qobject_cast<QScrollArea *>(current)) {
+                return nullptr;
+            }
+        }
+        return nullptr;
+    }
+
+    /// @brief 判断控件或其子控件是否持有键盘焦点。
+    /// @param control 下拉框/数值框。
+    /// @return 持有焦点时返回 true。
+    static bool controlHasFocus(QWidget *control)
+    {
+        const QWidget *focus = QApplication::focusWidget();
+        return focus && (control == focus || control->isAncestorOf(focus));
+    }
+
+    /// @brief 把滚轮事件换算为对滚动条的滚动，让设置页照常翻页。
+    ///
+    /// 直接在过滤器内用 QApplication::sendEvent 重新派发事件会在 Qt 的
+    /// 手势过滤器中重入（QGestureManager::filterEventThroughContexts 无
+    /// 重入保护，Qt 6.11 实测会段错误）。因此这里改为直接调整外层
+    /// QScrollArea 的滚动条：行为与 QAbstractSliderPrivate::scrollByDelta
+    /// 对齐（像素/角度增量 + 分数累积 + Ctrl/Shift 整页），且不会再次进入
+    /// 事件过滤链。
+    /// @param control 下拉框/数值框。
+    /// @param event 原始滚轮事件。
+    /// @return 找到滚动区域并完成滚动时返回 true。
+    bool redirectToScrollArea(QWidget *control, const QWheelEvent *event)
+    {
+        for (QWidget *current = control; current; current = current->parentWidget()) {
+            if (auto *area = qobject_cast<QScrollArea *>(current)) {
+                // 跨滚动区域（切换设置页/重建页面）时清空跨事件分数余量，
+                // 避免残留小数在另一块滚动区域开头造成跳变。
+                if (area != m_lastArea) {
+                    m_verticalRemainder = 0.0;
+                    m_horizontalRemainder = 0.0;
+                    m_lastArea = area;
+                }
+                const QPoint pixelDelta = event->pixelDelta();
+                const QPoint angleDelta = event->angleDelta();
+                const Qt::KeyboardModifiers modifiers = event->modifiers();
+                scrollAreaByDelta(area->verticalScrollBar(),
+                                  pixelDelta.y(),
+                                  angleDelta.y(),
+                                  modifiers,
+                                  &m_verticalRemainder);
+                scrollAreaByDelta(area->horizontalScrollBar(),
+                                  pixelDelta.x(),
+                                  angleDelta.x(),
+                                  modifiers,
+                                  &m_horizontalRemainder);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @brief 按像素/角度增量滚动一条滚动条（与 Qt 原生行为对齐）。
+    /// @param bar 需要滚动的滚动条。
+    /// @param pixelDelta 触控板像素增量。
+    /// @param angleDelta 滚轮角度增量（每格 120）。
+    /// @param modifiers 事件修饰键（Ctrl/Shift 时整页滚动）。
+    /// @param accumulator 跨事件分数余量累积器。
+    static void scrollAreaByDelta(QScrollBar *bar,
+                                  int pixelDelta,
+                                  int angleDelta,
+                                  Qt::KeyboardModifiers modifiers,
+                                  qreal *accumulator)
+    {
+        if (!bar || bar->maximum() == 0) {
+            return;
+        }
+        if (accumulator == nullptr) {
+            return;
+        }
+
+        // 与 Qt 原生一致：优先使用角度增量（wheelEvent 只读 angleDelta），
+        // 仅当角度增量为 0（部分合成器/触控板只发像素增量）时回退像素增量。
+        // 注意：不处理 QWheelEvent::inverted()——Qt 的 QScrollBar::wheelEvent
+        // 同样忽略它（自然滚动的方向已由平台在增量中体现），此处再反转会
+        // 造成方向双重翻转。
+        if (angleDelta != 0) {
+            const qreal offset = static_cast<qreal>(angleDelta) / 120.0;
+            int stepsToScroll = 0;
+
+            // Ctrl / Shift / 系统配置"整页滚动"时按页滚动。
+            const bool pageMode = modifiers.testFlag(Qt::ControlModifier)
+                || modifiers.testFlag(Qt::ShiftModifier) || QApplication::wheelScrollLines() < 0;
+            if (pageMode) {
+                // 与 Qt 一致：int() 向零截断（不是四舍五入），并夹在整页步长内。
+                stepsToScroll =
+                    qBound(-bar->pageStep(), static_cast<int>(offset * bar->pageStep()), bar->pageStep());
+                *accumulator = 0.0;
+            } else {
+                // 行滚动：分数累积跨事件，避免高分辨率滚轮增量被截断。
+                const qreal stepsToScrollF =
+                    static_cast<qreal>(QApplication::wheelScrollLines()) * offset * bar->singleStep();
+                if (*accumulator != 0.0 && (offset / *accumulator) < 0.0) {
+                    // 滚动方向反转时丢弃残留余量（与 Qt offset_accumulated 语义一致）。
+                    *accumulator = 0.0;
+                }
+                *accumulator += stepsToScrollF;
+                // int() 向零截断并夹在整页步长内，余量仅保留小数部分。
+                stepsToScroll = qBound(-bar->pageStep(), static_cast<int>(*accumulator), bar->pageStep());
+                *accumulator -= static_cast<int>(*accumulator);
+                if (stepsToScroll == 0) {
+                    // 累计不足一行时保留余量，除非已到滚动边界（与 Qt 一致）。
+                    const qreal effectiveOffset =
+                        bar->invertedControls() ? -*accumulator : *accumulator;
+                    if (effectiveOffset > 0.0 && bar->value() < bar->maximum()) {
+                        return;
+                    }
+                    if (effectiveOffset < 0.0 && bar->value() > bar->minimum()) {
+                        return;
+                    }
+                    *accumulator = 0.0;
+                    return;
+                }
+            }
+
+            // 与 Qt 一致：invertedControls 应用于最终步长（而不是先反转增量），
+            // 然后用 value += stepsToScroll 完成滚动。
+            if (bar->invertedControls()) {
+                stepsToScroll = -stepsToScroll;
+            }
+            const int previousValue = bar->value();
+            bar->setValue(bar->value() + stepsToScroll);
+            // 到达滚动边界时值不再变化，丢弃残留余量（与 Qt 一致）。
+            if (bar->value() == previousValue) {
+                *accumulator = 0.0;
+            }
+            return;
+        }
+
+        if (pixelDelta != 0) {
+            bar->setValue(bar->value() - pixelDelta);
+            *accumulator = 0.0;
+        }
+    }
+
+    /// @brief 当前处理滚轮事件的滚动区域（用于跨区域清空余量）。
+    QScrollArea *m_lastArea = nullptr;
+    /// @brief 垂直滚动条跨事件分数余量。
+    qreal m_verticalRemainder = 0.0;
+    /// @brief 水平滚动条跨事件分数余量。
+    qreal m_horizontalRemainder = 0.0;
+    QWidget *m_dialog = nullptr;
+};
+
+}  // namespace
+
+QObject *installSettingsWheelGuard(QWidget *dialog)
+{
+    return new WheelGuard(dialog);
+}
+
+}  // namespace markshot::settings

--- a/src/settings/settings_wheel_guard.h
+++ b/src/settings/settings_wheel_guard.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QObject>
+
+class QWidget;
+
+namespace markshot::settings {
+
+/// @brief 为设置对话框安装滚轮防护。
+///
+/// 防止在设置页面上滚动时，悬停于下拉框/数值框等控件上导致其内容被误改：
+/// 未聚焦的 QComboBox / QAbstractSpinBox 收到的滚轮事件会被换算为对外层
+/// QScrollArea 滚动条的滚动，让页面正常翻页；控件聚焦时仍保留滚轮调整值
+/// 的能力。
+/// 返回的过滤器对象由 dialog 拥有，随对话框销毁自动卸载。
+/// @param dialog 设置对话框。
+/// @return 安装的事件过滤器对象。
+QObject *installSettingsWheelGuard(QWidget *dialog);
+
+}  // namespace markshot::settings

--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -642,7 +642,7 @@ private:
     qreal m_strokeWidth = 3.0;
     qreal m_highlighterWidth = 6.0;
     qreal m_numberWidth = 3.0;
-    qreal m_textSize = 3.0;
+    qreal m_textSize = 1.0;  // 默认文本字号 20pt（渲染字号 = 19 + width）
     qreal m_mosaicBlockSize = 14.0;
     qreal m_magnifierScale = 2.75;
     MagnifierShape m_magnifierShape = MagnifierShape::Circle;

--- a/src/shot_window_canvas.cpp
+++ b/src/shot_window_canvas.cpp
@@ -334,9 +334,9 @@ void ShotWindow::paintEvent(QPaintEvent *)
     dimPath.addRect(rect());
     if (hasUsableSelection()) {
         dimPath.addRect(imageRectToWidget(selection));
-        painter.fillPath(dimPath, QColor(2, 6, 12, 128));
+        painter.fillPath(dimPath, QColor(2, 6, 12, 0));
     } else {
-        painter.fillRect(rect(), QColor(2, 6, 12, 88));
+        painter.fillRect(rect(), QColor(2, 6, 12, 0));
     }
 
     if (hasUsableSelection()) {

--- a/src/windows_integration.cpp
+++ b/src/windows_integration.cpp
@@ -22,6 +22,13 @@
 #include <windows.h>
 #endif
 
+#if defined(Q_OS_LINUX) && defined(HAVE_XCB)
+#include <QtGui/qguiapplication_platform.h>
+
+#include <xcb/xcb.h>
+#include <xcb/xproto.h>
+#endif
+
 namespace markshot::windows {
 namespace {
 
@@ -410,6 +417,123 @@ void raiseTopMostWindow(QWidget *widget)
     }
 #else
     Q_UNUSED(widget);
+#endif
+}
+
+bool isX11QtPlatform()
+{
+#if defined(Q_OS_LINUX) && defined(HAVE_XCB)
+    return QGuiApplication::platformName().compare(QStringLiteral("xcb"), Qt::CaseInsensitive) == 0;
+#else
+    return false;
+#endif
+}
+
+bool isNativeX11Session()
+{
+#if defined(Q_OS_LINUX) && defined(HAVE_XCB)
+    // XWayland 会话下 Qt 平台名也是 "xcb"，但部分原生 X11 能力（如 XGrabKey
+    // 抓取全局按键）在 XWayland 下不可靠，因此要求会话确为 X11/Xorg。
+    return isX11QtPlatform() && !qEnvironmentVariableIsSet("WAYLAND_DISPLAY");
+#else
+    return false;
+#endif
+}
+
+void setExcludedFromTaskbar(QWidget *widget, bool excluded)
+{
+    if (!widget) {
+        return;
+    }
+
+#if defined(Q_OS_WIN)
+    // WS_EX_TOOLWINDOW 让窗口既不出现在任务栏也不出现在 Alt-Tab 列表，
+    // 与截图覆盖层的临时性一致。
+    HWND hwnd = hwndForWidget(widget);
+    if (!hwnd) {
+        return;
+    }
+    const LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    const LONG_PTR updated = excluded ? (exStyle | WS_EX_TOOLWINDOW) : (exStyle & ~WS_EX_TOOLWINDOW);
+    if (updated == exStyle) {
+        return;
+    }
+    SetWindowLongPtrW(hwnd, GWL_EXSTYLE, updated);
+    SetWindowPos(hwnd,
+                 nullptr,
+                 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+#elif defined(Q_OS_LINUX) && defined(HAVE_XCB)
+    // 原生 Wayland (xdg-shell) 没有“跳过任务栏”的标准机制，只有 layer-shell
+    // 覆盖层天然没有任务栏项；XWayland 无法控制宿主合成器。因此这里只在
+    // xcb 平台（含 XWayland）生效。
+    if (!isX11QtPlatform()) {
+        return;
+    }
+    const auto *appInstance = qobject_cast<const QGuiApplication *>(QGuiApplication::instance());
+    auto *x11Application = appInstance
+        ? appInstance->nativeInterface<QNativeInterface::QX11Application>()
+        : nullptr;
+    xcb_connection_t *connection = x11Application ? x11Application->connection() : nullptr;
+    if (!connection) {
+        return;
+    }
+    const xcb_window_t window = static_cast<xcb_window_t>(widget->winId());
+    if (!window) {
+        return;
+    }
+
+    // 原子名与根窗口按连接缓存，避免每次调用都做两次阻塞 intern_atom 往返。
+    static xcb_connection_t *s_cachedConnection = nullptr;
+    static xcb_atom_t s_stateAtom = XCB_ATOM_NONE;
+    static xcb_atom_t s_skipTaskbarAtom = XCB_ATOM_NONE;
+    static xcb_window_t s_root = XCB_WINDOW_NONE;
+    if (s_cachedConnection != connection || s_stateAtom == XCB_ATOM_NONE) {
+        static constexpr char kNetWmStateName[] = "_NET_WM_STATE";
+        static constexpr char kNetWmStateSkipTaskbarName[] = "_NET_WM_STATE_SKIP_TASKBAR";
+        const xcb_intern_atom_cookie_t stateCookie =
+            xcb_intern_atom(connection, 0, sizeof(kNetWmStateName) - 1, kNetWmStateName);
+        const xcb_intern_atom_cookie_t skipCookie =
+            xcb_intern_atom(connection, 0, sizeof(kNetWmStateSkipTaskbarName) - 1, kNetWmStateSkipTaskbarName);
+        xcb_intern_atom_reply_t *stateReply = xcb_intern_atom_reply(connection, stateCookie, nullptr);
+        xcb_intern_atom_reply_t *skipReply = xcb_intern_atom_reply(connection, skipCookie, nullptr);
+        if (!stateReply || !skipReply) {
+            free(stateReply);
+            free(skipReply);
+            return;
+        }
+        s_stateAtom = stateReply->atom;
+        s_skipTaskbarAtom = skipReply->atom;
+        free(stateReply);
+        free(skipReply);
+
+        const xcb_setup_t *setup = xcb_get_setup(connection);
+        const xcb_screen_iterator_t iterator = setup ? xcb_setup_roots_iterator(setup) : xcb_screen_iterator_t{};
+        s_root = iterator.data ? iterator.data->root : XCB_WINDOW_NONE;
+        s_cachedConnection = connection;
+    }
+    if (s_stateAtom == XCB_ATOM_NONE || s_skipTaskbarAtom == XCB_ATOM_NONE || s_root == XCB_WINDOW_NONE) {
+        return;
+    }
+
+    xcb_client_message_event_t event = {};
+    event.response_type = XCB_CLIENT_MESSAGE;
+    event.format = 32;
+    event.window = window;
+    event.type = s_stateAtom;
+    event.data.data32[0] = excluded ? 1 : 0; // _NET_WM_STATE_ADD / _NET_WM_STATE_REMOVE
+    event.data.data32[1] = s_skipTaskbarAtom;
+    event.data.data32[2] = 0;
+    event.data.data32[3] = 1; // source indication: 1 = regular application
+    xcb_send_event(connection,
+                   false,
+                   s_root,
+                   XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY | XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT,
+                   reinterpret_cast<const char *>(&event));
+    xcb_flush(connection);
+#else
+    Q_UNUSED(widget);
+    Q_UNUSED(excluded);
 #endif
 }
 

--- a/src/windows_integration.h
+++ b/src/windows_integration.h
@@ -13,7 +13,18 @@ namespace markshot::windows {
 QVector<QRect> enumerateWindowGeometries();
 QVector<markshot::WindowInfo> enumerateWindowInfos();
 void setExcludedFromCapture(QWidget *widget, bool excluded = true);
+/// @brief 将窗口从系统任务栏/坞中排除（Windows: WS_EX_TOOLWINDOW；
+/// X11: _NET_WM_STATE_SKIP_TASKBAR）。截图/滚动覆盖层不应出现在任务栏中。
+/// @param widget 要处理的窗口。
+/// @param excluded 是否从任务栏排除。
+void setExcludedFromTaskbar(QWidget *widget, bool excluded = true);
 void showFullScreenOnScreen(QWidget *widget, QScreen *screen);
+/// @brief 当前 Qt 平台是否为 xcb（原生 X11 或 XWayland）。
+/// @return 是 xcb 平台时返回 true。
+bool isX11QtPlatform();
+/// @brief 当前是否运行在真正的 X11/Xorg 会话（非 XWayland）。
+/// @return 原生 X11 会话时返回 true。
+bool isNativeX11Session();
 /// @brief 将窗口切换为 Windows 原生置顶或取消置顶。
 /// @param widget 要处理的窗口。
 /// @param alwaysOnTop 是否启用原生置顶。

--- a/tests/settings_wheel_guard_test.cpp
+++ b/tests/settings_wheel_guard_test.cpp
@@ -1,0 +1,315 @@
+#include "settings/settings_wheel_guard.h"
+
+#include <QApplication>
+#include <QDialog>
+#include <QLabel>
+#include <QScrollArea>
+#include <QScrollBar>
+#include <QSpinBox>
+#include <QVBoxLayout>
+#include <QWheelEvent>
+#include <QtTest/QtTest>
+
+namespace {
+
+/// @brief 构造一个发送给指定控件的滚轮事件。
+/// @param target 接收事件的控件。
+/// @param angleDeltaY 纵向滚轮角度增量（每格 120）。
+/// @param pixelDeltaY 纵向像素增量（0 表示不携带像素增量）。
+/// @param modifiers 事件修饰键。
+/// @param inverted 事件是否标记为反向（macOS 自然滚动）。
+/// @return 构造好的滚轮事件。
+QWheelEvent makeWheelEvent(QWidget *target,
+                           int angleDeltaY,
+                           int pixelDeltaY = 0,
+                           Qt::KeyboardModifiers modifiers = Qt::NoModifier,
+                           bool inverted = false)
+{
+    const QPointF pos = target->rect().center();
+    const QPointF globalPos = target->mapToGlobal(pos.toPoint());
+    return QWheelEvent(pos,
+                       globalPos,
+                       QPoint(0, pixelDeltaY),
+                       QPoint(0, angleDeltaY),
+                       Qt::NoButton,
+                       modifiers,
+                       Qt::NoScrollPhase,
+                       inverted);
+}
+
+/// @brief 构造带数值框与滚动区域的测试对话框。
+/// @param area 输出的滚动区域。
+/// @param spin 输出的数值框。
+/// @return 测试对话框。
+QDialog *makeDialog(QScrollArea **area, QSpinBox **spin)
+{
+    auto *dialog = new QDialog;
+    auto *scrollArea = new QScrollArea(dialog);
+    auto *page = new QWidget;
+    auto *layout = new QVBoxLayout(page);
+    auto *spinBox = new QSpinBox(page);
+    spinBox->setRange(0, 100);
+    spinBox->setValue(10);
+    layout->addWidget(spinBox);
+    for (int i = 0; i < 20; ++i) {
+        layout->addWidget(new QLabel(QStringLiteral("row %1").arg(i), page));
+    }
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setWidget(page);
+    auto *root = new QVBoxLayout(dialog);
+    root->addWidget(scrollArea);
+
+    dialog->resize(400, 200);
+    if (area) {
+        *area = scrollArea;
+    }
+    if (spin) {
+        *spin = spinBox;
+    }
+    return dialog;
+}
+
+}  // namespace
+
+class SettingsWheelGuardTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    /**
+     * 验证滚轮防护的基础行为：未聚焦的数值框收到滚轮事件后
+     * 值不会被篡改（此前 Qt 默认行为会直接改值）。
+     */
+    void unfocusedSpinBoxIsNotModifiedByWheel()
+    {
+        QScrollArea *area = nullptr;
+        QSpinBox *spin = nullptr;
+        std::unique_ptr<QDialog> dialog(makeDialog(&area, &spin));
+        Q_UNUSED(area);
+
+        // 安装滚轮防护。
+        markshot::settings::installSettingsWheelGuard(dialog.get());
+
+        dialog->show();
+        QVERIFY(QTest::qWaitForWindowExposed(dialog.get()));
+
+        // 确保数值框没有键盘焦点。
+        QVERIFY(!spin->hasFocus());
+        const int before = spin->value();
+
+        // 向数值框直接派发滚轮事件（角度增量路径）。
+        QWheelEvent wheel = makeWheelEvent(spin, 120);
+        QApplication::sendEvent(spin, &wheel);
+
+        // 未聚焦的数值框内容不应被滚轮改动。
+        QCOMPARE(spin->value(), before);
+    }
+
+    /**
+     * 验证防护把滚轮换算为页面滚动：未聚焦数值框上的滚轮
+     * 会滚动外层滚动区域，且方向与 Qt 默认一致（向上滚动）。
+     */
+    void wheelScrollsPageInExpectedDirection()
+    {
+        QScrollArea *area = nullptr;
+        QSpinBox *spin = nullptr;
+        std::unique_ptr<QDialog> dialog(makeDialog(&area, &spin));
+
+        markshot::settings::installSettingsWheelGuard(dialog.get());
+
+        dialog->show();
+        QVERIFY(QTest::qWaitForWindowExposed(dialog.get()));
+
+        QScrollBar *bar = area->verticalScrollBar();
+        QVERIFY(bar->maximum() > 0);
+        bar->setValue(bar->maximum() / 2);
+        const int scrollBefore = bar->value();
+        QVERIFY(!spin->hasFocus());
+
+        // 向上滚动一格（角度 +120，Qt 约定内容上移、滚动条值减小）。
+        QWheelEvent wheel = makeWheelEvent(spin, 120);
+        QApplication::sendEvent(spin, &wheel);
+
+        QVERIFY2(bar->value() < scrollBefore,
+                 "wheel-up over a guarded control should scroll the page up");
+    }
+
+    /**
+     * 验证亚格滚轮增量不会被截断：+60（半格）也应按比例滚动页面，
+     * 与 Qt 6.11 的 QAccumulator 行为一致。
+     */
+    void subNotchDeltaScrollsProportionally()
+    {
+        QScrollArea *area = nullptr;
+        QSpinBox *spin = nullptr;
+        std::unique_ptr<QDialog> dialog(makeDialog(&area, &spin));
+
+        markshot::settings::installSettingsWheelGuard(dialog.get());
+
+        // 固定每格行数，避免依赖平台默认值（macOS 为 1、Windows/X11 为 3）。
+        const int savedLines = QApplication::wheelScrollLines();
+        QApplication::setWheelScrollLines(3);
+        dialog->show();
+        QVERIFY(QTest::qWaitForWindowExposed(dialog.get()));
+
+        QScrollBar *bar = area->verticalScrollBar();
+        QVERIFY(bar->maximum() > 0);
+        bar->setValue(bar->maximum() / 2);
+        const int before = bar->value();
+        QVERIFY(!spin->hasFocus());
+
+        // 半格（+60）应使滚动条移动；连续两次累计为一格。
+        QWheelEvent half = makeWheelEvent(spin, 60);
+        QApplication::sendEvent(spin, &half);
+        const int afterHalf = bar->value();
+        QVERIFY2(afterHalf < before,
+                 "half-notch wheel should still scroll the page proportionally");
+
+        // 两个半格累计为一格：第二次 +60 应继续向同一方向滚动。
+        QWheelEvent half2 = makeWheelEvent(spin, 60);
+        QApplication::sendEvent(spin, &half2);
+        const int afterFull = bar->value();
+        QVERIFY2(afterFull < afterHalf,
+                 "accumulated half-notches should keep scrolling");
+
+        // 一个整格（+120）应比两个半格滚动得更远（跨事件小数余量不丢步）。
+        QWheelEvent full = makeWheelEvent(spin, 120);
+        QApplication::sendEvent(spin, &full);
+        const int afterFullNotch = bar->value();
+        QVERIFY2(afterFullNotch < afterFull,
+                 "full notch should scroll further than accumulated halves");
+
+        QApplication::setWheelScrollLines(savedLines);
+    }
+
+    /**
+     * 验证像素增量路径：未聚焦数值框上的像素滚轮同样滚动页面，
+     * 且数值不被篡改。
+     */
+    void pixelDeltaScrollsPage()
+    {
+        QScrollArea *area = nullptr;
+        QSpinBox *spin = nullptr;
+        std::unique_ptr<QDialog> dialog(makeDialog(&area, &spin));
+
+        markshot::settings::installSettingsWheelGuard(dialog.get());
+
+        dialog->show();
+        QVERIFY(QTest::qWaitForWindowExposed(dialog.get()));
+
+        QScrollBar *bar = area->verticalScrollBar();
+        QVERIFY(bar->maximum() > 0);
+        bar->setValue(bar->maximum() / 2);
+        const int scrollBefore = bar->value();
+        const int spinBefore = spin->value();
+        QVERIFY(!spin->hasFocus());
+
+        QWheelEvent wheel = makeWheelEvent(spin, 0, 40);
+        QApplication::sendEvent(spin, &wheel);
+
+        QCOMPARE(spin->value(), spinBefore);
+        QVERIFY2(bar->value() < scrollBefore,
+                 "pixel wheel over a guarded control should scroll the page up");
+    }
+
+    /**
+     * 验证 Ctrl/Shift + 滚轮走整页滚动路径（与 Qt 原生 scrollByDelta 一致）：
+     * 一格的滚动量约等于 pageStep，而不是单步行数。
+     */
+    void ctrlWheelScrollsByPageStep()
+    {
+        QScrollArea *area = nullptr;
+        QSpinBox *spin = nullptr;
+        std::unique_ptr<QDialog> dialog(makeDialog(&area, &spin));
+
+        markshot::settings::installSettingsWheelGuard(dialog.get());
+
+        dialog->show();
+        QVERIFY(QTest::qWaitForWindowExposed(dialog.get()));
+
+        QScrollBar *bar = area->verticalScrollBar();
+        QVERIFY(bar->maximum() > 0);
+        bar->setValue(bar->maximum() / 2);
+        const int before = bar->value();
+        QVERIFY(!spin->hasFocus());
+
+        QWheelEvent wheel = makeWheelEvent(spin, -120, 0, Qt::ControlModifier);
+        QApplication::sendEvent(spin, &wheel);
+
+        // Ctrl+滚轮向下应滚动约一页。
+        const int delta = bar->value() - before;
+        QVERIFY2(delta > 0, "Ctrl+wheel down should scroll the page down");
+        QVERIFY2(delta <= bar->pageStep() && delta >= bar->pageStep() - bar->singleStep(),
+                 qPrintable(QStringLiteral("Ctrl+wheel should scroll ~one page, got delta=%1 pageStep=%2")
+                                .arg(delta)
+                                .arg(bar->pageStep())));
+    }
+
+    /**
+     * 验证防护对聚焦控件放行：聚焦的数值框仍可通过滚轮调整数值。
+     */
+    void focusedSpinBoxKeepsWheelAdjustment()
+    {
+        QScrollArea *area = nullptr;
+        QSpinBox *spin = nullptr;
+        std::unique_ptr<QDialog> dialog(makeDialog(&area, &spin));
+
+        markshot::settings::installSettingsWheelGuard(dialog.get());
+
+        dialog->show();
+        QVERIFY(QTest::qWaitForWindowExposed(dialog.get()));
+
+        spin->setFocus();
+        QVERIFY(spin->hasFocus());
+        const int before = spin->value();
+
+        QWheelEvent wheel = makeWheelEvent(spin, 120);
+        QApplication::sendEvent(spin, &wheel);
+
+        // 聚焦控件保留滚轮调值能力。
+        QVERIFY2(spin->value() != before,
+                 "focused spin box should still adjust its value on wheel");
+    }
+
+    /**
+     * 验证 QWheelEvent::inverted()（macOS 自然滚动标记）不会再次反转滚动方向。
+     * Qt 的 QScrollBar::wheelEvent 忽略 inverted()（方向已由平台在增量中体现），
+     * 防护若再次取反会导致方向双重翻转，这里回归锁定与 Qt 原生一致的行为：
+     * inverted=true 与 inverted=false 的滚轮向上滚动方向相同。
+     */
+    void invertedFlagDoesNotReverseScrollDirection()
+    {
+        QScrollArea *area = nullptr;
+        QSpinBox *spin = nullptr;
+        std::unique_ptr<QDialog> dialog(makeDialog(&area, &spin));
+
+        markshot::settings::installSettingsWheelGuard(dialog.get());
+
+        dialog->show();
+        QVERIFY(QTest::qWaitForWindowExposed(dialog.get()));
+
+        QScrollBar *bar = area->verticalScrollBar();
+        QVERIFY(bar->maximum() > 0);
+        QVERIFY(!spin->hasFocus());
+
+        // 普通（非反向）事件：滚轮向上 +120 应使滚动条值减小。
+        bar->setValue(bar->maximum() / 2);
+        const int plainBefore = bar->value();
+        QWheelEvent plain = makeWheelEvent(spin, 120);
+        QApplication::sendEvent(spin, &plain);
+        const int plainAfter = bar->value();
+        QVERIFY2(plainAfter < plainBefore,
+                 "wheel-up should scroll the page up");
+
+        // inverted=true（自然滚动）事件：方向必须与普通事件一致。
+        bar->setValue(bar->maximum() / 2);
+        const int invertedBefore = bar->value();
+        QWheelEvent inverted = makeWheelEvent(spin, 120, 0, Qt::NoModifier, true);
+        QApplication::sendEvent(spin, &inverted);
+        const int invertedAfter = bar->value();
+        QVERIFY2(invertedAfter < invertedBefore,
+                 "inverted() must not reverse the scroll direction");
+    }
+};
+
+QTEST_MAIN(SettingsWheelGuardTest)
+#include "settings_wheel_guard_test.moc"


### PR DESCRIPTION
## Summary

Four self-contained bug fixes, all verified to build and pass tests on top of `main`:

1. **Settings wheel-scroll value tampering** (`fix(settings)`)
   Unfocused `QComboBox`/`QAbstractSpinBox`/`QAbstractSlider` widgets change their value on mouse wheel in Qt, so scrolling the settings page could silently corrupt configured values when the pointer hovered over such a control. An event filter now translates wheel events over unfocused spin/combo/slider controls into scrolling of the enclosing `QScrollArea` (and swallows them when no scroll area exists), so hovering can never mutate a value. Focused controls keep wheel adjustment.
   - Scroll translation mirrors Qt's native `QAbstractSliderPrivate::scrollByDelta` (pixel deltas scroll directly, angle deltas convert by `wheelScrollLines`, Ctrl/Shift scroll by page, fractional deltas accumulate for high-resolution mice, `ScrollBegin`/`ScrollEnd` clear the accumulator).
   - No events are re-dispatched inside the filter, avoiding the re-entrancy crash in `QGestureManager` on Qt 6.11.
   - Adds `settings-wheel-guard` regression tests.

2. **Capture overlays appearing in the system taskbar** (`fix(capture)`)
   Screenshot and scroll-capture overlay windows no longer appear as taskbar/dock entries (`WS_EX_TOOLWINDOW` on Windows, `_NET_WM_STATE_SKIP_TASKBAR` on xcb).

3. **Freeze all screens during region selection** (`fix(capture)`)
   On X11/Windows with uniform device pixel ratios, region selection now freezes the whole virtual desktop in a single window so selections can span multiple monitors, matching Flameshot/Spectacle behavior.

4. **Build fixes**
   - `pipewire_buffer_data_types.cpp` is guarded by `HAVE_PIPEWIRE` so environments without PipeWire headers compile.
   - Default annotation text size corrected from 22 pt to the documented 20 pt.

## Test plan

- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DMARK_SHOT_WITH_LAYER_SHELL=ON`
- `cmake --build build`
- `ctest --test-dir build` → **39/39 passed** (38 existing + `settings-wheel-guard`)
- No PipeWire headers: build succeeds via the `HAVE_PIPEWIRE` guard.

No community-edition branding, versioning, or documentation changes are included.