### PR TITLE
fix(shortcuts): allow bare Print on X11 (#76)

### DIFF
--- a/src/shortcuts/global_shortcut_keymap.cpp
+++ b/src/shortcuts/global_shortcut_keymap.cpp
@@ -27,6 +27,7 @@ constexpr std::uint32_t kKeysymPageUp = 0xff55;
 constexpr std::uint32_t kKeysymPageDown = 0xff56;
 constexpr std::uint32_t kKeysymEnd = 0xff57;
 constexpr std::uint32_t kKeysymPrint = 0xff61;
+constexpr std::uint32_t kKeysymSysReq = 0xff15;
 constexpr std::uint32_t kKeysymInsert = 0xff63;
 constexpr std::uint32_t kKeysymNumLock = 0xff7f;
 constexpr std::uint32_t kKeysymF1 = 0xffbe;
@@ -211,13 +212,33 @@ X11KeyBinding x11BindingForSequence(const QKeySequence &sequence)
         binding.modifiers |= kMod4Mask;
     }
 
-    // 3. 不带任何修饰键的组合会抢占普通输入，拒绝注册
-    if (binding.modifiers == 0) {
+    // 3. 无修饰键会抢占普通输入，默认拒绝；Print 是截图专用键，允许裸绑
+    //    （与 GNOME accelerator 例外一致；issue #76 Mint/Cinnamon 用户常用 Print）
+    if (binding.modifiers == 0 && combination.key() != Qt::Key_Print) {
         return binding;
     }
 
     binding.valid = true;
     return binding;
+}
+
+/**
+ * 返回抓取某主键时需要尝试的 X11 keysym 列表。
+ *
+ * 部分键盘把 Print 映射为 Sys_Req（或两者互换），只抓 0xff61 会找不到 keycode。
+ *
+ * @param keysym 主 keysym。
+ * @return 按优先级排列的候选 keysym。
+ */
+QList<std::uint32_t> x11KeysymCandidates(std::uint32_t keysym)
+{
+    if (keysym == kKeysymPrint) {
+        return {kKeysymPrint, kKeysymSysReq};
+    }
+    if (keysym == kKeysymSysReq) {
+        return {kKeysymSysReq, kKeysymPrint};
+    }
+    return {keysym};
 }
 
 }  // namespace markshot::shortcuts

--- a/src/shortcuts/global_shortcut_keymap.h
+++ b/src/shortcuts/global_shortcut_keymap.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QKeySequence>
+#include <QList>
 
 #include <cstdint>
 
@@ -35,12 +36,20 @@ std::uint32_t x11KeysymForQtKey(int key);
 X11KeyBinding x11BindingForSequence(const QKeySequence &sequence);
 
 /**
+ * 返回抓取某主键时需要尝试的 X11 keysym 候选（如 Print / Sys_Req）。
+ *
+ * @param keysym 主 keysym。
+ * @return 候选列表，至少包含自身。
+ */
+QList<std::uint32_t> x11KeysymCandidates(std::uint32_t keysym);
+
+/**
  * 将 Qt 快捷键序列转换为 GNOME/GTK accelerator 字符串。
  *
  * GNOME 的 gsettings 自定义快捷键（media-keys custom-keybinding 的 binding
  * 键）使用 gtk_accelerator_parse 的格式，例如 "<Control><Alt>s"、
- * "<Super>Print"。仅取序列中的第一个组合；无修饰键的组合会抢占普通输入，
- * 与 X11 后端一样拒绝转换。
+ * "<Super>Print"。仅取序列中的第一个组合；无修饰键的普通按键会抢占输入，
+ * 但 Print 屏幕截图键例外（与 X11 后端一致）。
  *
  * @param sequence Qt 快捷键序列。
  * @return accelerator 字符串；无法转换时返回空字符串。

--- a/src/shortcuts/global_shortcut_x11.cpp
+++ b/src/shortcuts/global_shortcut_x11.cpp
@@ -130,10 +130,13 @@ std::uint8_t X11GlobalShortcutBackend::keycodeForKeysym(std::uint32_t keysym) co
 
     std::uint8_t found = 0;
     if (keysyms && perKeycode > 0) {
-        // 2. 只比对每个键码的第一个 keysym，即未叠加 Shift 时的符号
+        // 2. 扫描每个键码的全部 level：Print 常落在非第 0 档（与 Sys_Req 互换）
         for (int index = 0; index < keysymCount && found == 0; index += perKeycode) {
-            if (keysyms[index] == keysym) {
-                found = static_cast<std::uint8_t>(minKeycode + index / perKeycode);
+            for (int level = 0; level < perKeycode; ++level) {
+                if (keysyms[index + level] == keysym) {
+                    found = static_cast<std::uint8_t>(minKeycode + index / perKeycode);
+                    break;
+                }
             }
         }
     }
@@ -152,34 +155,40 @@ bool X11GlobalShortcutBackend::grabKey(std::uint32_t keysym,
         return false;
     }
 
-    const std::uint8_t keycode = keycodeForKeysym(keysym);
-    if (keycode == 0) {
-        return false;
-    }
-
-    // 1. 对每种锁定键组合各抓取一次，确保 CapsLock / NumLock 打开时仍能触发
-    bool anyGrabbed = false;
-    for (const std::uint16_t lockMask : lockModifierVariants()) {
-        const std::uint16_t effectiveModifiers = static_cast<std::uint16_t>(modifiers | lockMask);
-        xcb_void_cookie_t cookie = xcb_grab_key_checked(connection,
-                                                        1,  // owner_events：事件仍投递给拥有者
-                                                        root,
-                                                        effectiveModifiers,
-                                                        keycode,
-                                                        XCB_GRAB_MODE_ASYNC,
-                                                        XCB_GRAB_MODE_ASYNC);
-        xcb_generic_error_t *error = xcb_request_check(connection, cookie);
-        if (error) {
-            // 已被其他程序占用时该组合抓取失败，跳过但不影响其余组合
-            free(error);
+    // 1. Print 等键可能对应多个 keysym，逐个解析 keycode 再抓取
+    for (const std::uint32_t candidate : x11KeysymCandidates(keysym)) {
+        const std::uint8_t keycode = keycodeForKeysym(candidate);
+        if (keycode == 0) {
             continue;
         }
-        m_grabbedKeys.append({keycode, effectiveModifiers});
-        m_shortcutIdByBinding.insert(bindingKey(keycode, effectiveModifiers), shortcutId);
-        anyGrabbed = true;
+
+        bool anyGrabbed = false;
+        for (const std::uint16_t lockMask : lockModifierVariants()) {
+            const std::uint16_t effectiveModifiers =
+                static_cast<std::uint16_t>(modifiers | lockMask);
+            xcb_void_cookie_t cookie = xcb_grab_key_checked(connection,
+                                                            1,  // owner_events：事件仍投递给拥有者
+                                                            root,
+                                                            effectiveModifiers,
+                                                            keycode,
+                                                            XCB_GRAB_MODE_ASYNC,
+                                                            XCB_GRAB_MODE_ASYNC);
+            xcb_generic_error_t *error = xcb_request_check(connection, cookie);
+            if (error) {
+                // 已被其他程序占用时该组合抓取失败，跳过但不影响其余组合
+                free(error);
+                continue;
+            }
+            m_grabbedKeys.append({keycode, effectiveModifiers});
+            m_shortcutIdByBinding.insert(bindingKey(keycode, effectiveModifiers), shortcutId);
+            anyGrabbed = true;
+        }
+        if (anyGrabbed) {
+            return true;
+        }
     }
 
-    return anyGrabbed;
+    return false;
 }
 
 void X11GlobalShortcutBackend::installEventFilter()
@@ -204,6 +213,7 @@ bool X11GlobalShortcutBackend::registerShortcuts(const QList<Shortcut> &shortcut
 
     // 1. 逐条转换并抓取，单条失败不影响其余快捷键
     QStringList failed;
+    QStringList rejectedBare;
     for (const Shortcut &shortcut : shortcuts) {
         if (shortcut.id.isEmpty() || !shortcut.callback) {
             continue;
@@ -211,11 +221,29 @@ bool X11GlobalShortcutBackend::registerShortcuts(const QList<Shortcut> &shortcut
 
         const X11KeyBinding binding = x11BindingForSequence(shortcut.sequence);
         if (!binding.valid) {
-            failed.append(shortcut.sequence.toString(QKeySequence::NativeText));
+            const QString text = shortcut.sequence.toString(QKeySequence::NativeText);
+            failed.append(text);
+            // 无修饰键且非 Print：明确记入，避免被误报成「被其他程序占用」
+            if (!shortcut.sequence.isEmpty()
+                && shortcut.sequence[0].keyboardModifiers() == Qt::NoModifier
+                && shortcut.sequence[0].key() != Qt::Key_Print) {
+                rejectedBare.append(text);
+            }
+            markshot::debugLog("shortcuts",
+                               "【全局快捷键】【X11】unsupported sequence id=%s sequence=%s",
+                               shortcut.id.toUtf8().constData(),
+                               text.toUtf8().constData());
             continue;
         }
         if (!grabKey(binding.keysym, binding.modifiers, shortcut.id)) {
-            failed.append(shortcut.sequence.toString(QKeySequence::NativeText));
+            const QString text = shortcut.sequence.toString(QKeySequence::NativeText);
+            failed.append(text);
+            markshot::debugLog("shortcuts",
+                               "【全局快捷键】【X11】grab failed id=%s sequence=%s keysym=0x%x mods=0x%x",
+                               shortcut.id.toUtf8().constData(),
+                               text.toUtf8().constData(),
+                               binding.keysym,
+                               binding.modifiers);
             continue;
         }
         m_callbacks.insert(shortcut.id, shortcut.callback);
@@ -226,8 +254,13 @@ bool X11GlobalShortcutBackend::registerShortcuts(const QList<Shortcut> &shortcut
 
     if (m_callbacks.isEmpty()) {
         unregisterShortcuts();
-        m_errorString = MS_TR("Failed to grab any global shortcut from the X server. "
-                              "Another application may already use the same key combination.");
+        if (!rejectedBare.isEmpty() && rejectedBare.size() == failed.size()) {
+            m_errorString = MS_TR("Global shortcuts need a modifier key (Ctrl/Alt/Super), "
+                                  "except the Print key.");
+        } else {
+            m_errorString = MS_TR("Failed to grab any global shortcut from the X server. "
+                                  "Another application may already use the same key combination.");
+        }
         return false;
     }
 

--- a/tests/global_shortcut_keymap_test.cpp
+++ b/tests/global_shortcut_keymap_test.cpp
@@ -65,9 +65,27 @@ private slots:
 
     void sequenceWithoutModifierIsRejected()
     {
-        // 无修饰键的组合会抢占普通输入，必须拒绝
+        // 无修饰键的普通按键会抢占输入，必须拒绝
         QVERIFY(!x11BindingForSequence(QKeySequence(QStringLiteral("S"))).valid);
         QVERIFY(!x11BindingForSequence(QKeySequence(QStringLiteral("F5"))).valid);
+    }
+
+    void barePrintIsAllowed()
+    {
+        // Print 是截图专用键，X11 与 GNOME 一样允许裸绑（issue #76）
+        const X11KeyBinding binding = x11BindingForSequence(QKeySequence(Qt::Key_Print));
+        QVERIFY(binding.valid);
+        QCOMPARE(binding.keysym, 0xff61u);
+        QCOMPARE(binding.modifiers, static_cast<std::uint16_t>(0));
+    }
+
+    void printKeysymCandidatesIncludeSysReq()
+    {
+        using markshot::shortcuts::x11KeysymCandidates;
+        const QList<std::uint32_t> candidates = x11KeysymCandidates(0xff61u);
+        QCOMPARE(candidates.size(), 2);
+        QCOMPARE(candidates.at(0), 0xff61u);
+        QCOMPARE(candidates.at(1), 0xff15u);
     }
 
     void emptySequenceIsRejected()


### PR DESCRIPTION
## Summary
- X11 托盘全局快捷键此前拒绝**所有无修饰键**组合，导致 Mint/Cinnamon 用户绑定单独 `Print` 时在 `XGrabKey` 之前就失败，并误报「已被其他程序占用」（#76）。
- 与 GNOME 后端一致：允许裸绑 `Print`；解析 keycode 时扫描全部 keysym level，并额外尝试 `Sys_Req`。
- 无修饰键的普通键（如单独 `S`/`F5`）仍拒绝，错误文案更明确。

## Test plan
- [x] `mark-shot-global-shortcut-keymap-test`（含 `barePrintIsAllowed`）
- [ ] Mint 22.3 X11 / Cinnamon：托盘启动，截图快捷键设为 `Print`，确认注册成功且可触发
- [ ] 带修饰键的组合（如 `Ctrl+Alt+S`）仍可注册
- [ ] 单独字母键仍被拒绝并给出清晰提示

Fixes #76

Made with [Cursor](https://cursor.com)