### PR TITLE
fix(annotation): show correct tool name for marker

### DIFF
--- a/src/shot_window_annotation_editing.cpp
+++ b/src/shot_window_annotation_editing.cpp
@@ -525,8 +525,9 @@ QString ShotWindow::currentToolName() const
     case Tool::Rectangle:
         return QStringLiteral("Rect");
     case Tool::Ellipse:
-    case Tool::Marker:
         return QStringLiteral("Ellipse");
+    case Tool::Marker:
+        return QStringLiteral("Marker");
     case Tool::Arrow:
         return QStringLiteral("Arrow");
     case Tool::Text:


### PR DESCRIPTION
修复 marker 工具点击后，按钮图标未显示选中的问题。

bug 截图：
<img width="1706" height="1279" alt="52a5eef15fe2b3fbff7fd3f46d2f9d73" src="https://github.com/user-attachments/assets/68e0bfcf-b57a-4f6e-a20b-c3714a190a9d" />
