### PR TITLE
fix(shortcuts): escape gsettings values as GVariant string literals

### DIFF
--- a/src/shortcuts/global_shortcut_gnome.cpp
+++ b/src/shortcuts/global_shortcut_gnome.cpp
@@ -145,6 +145,25 @@ bool writeKeybindingList(const QStringList &paths, QString *errorText)
 }
 
 /**
+ * 把字符串转义为 gsettings 可接受的 GVariant 字符串字面量。
+ *
+ * gsettings set 的键值按 GVariant 语法解析，裸值在遇到空格或引号等
+ * 语法边界时会被截断（例如 selfCommand 生成的 "…/mark-shot" --capture
+ * 会报 expected end of input）。用单引号包裹并转义反斜杠与单引号后，
+ * 任意字符串都能原样写入 dconf。
+ *
+ * @param value 原始字符串。
+ * @return 可作为 gsettings set 键值参数传入的 GVariant 字符串字面量。
+ */
+QString escapeGvariantString(const QString &value)
+{
+    QString escaped = value;
+    escaped.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
+    escaped.replace(QLatin1Char('\''), QStringLiteral("\\'"));
+    return QStringLiteral("'%1'").arg(escaped);
+}
+
+/**
  * 设置一条 keybinding 的单个键值。
  *
  * @param path keybinding 路径。
@@ -161,7 +180,7 @@ bool writeKeybindingValue(const QString &path,
     return runGsettings({QStringLiteral("set"),
                          QStringLiteral("%1:%2").arg(QLatin1String(kCustomKeybindingSchema), path),
                          key,
-                         value},
+                         escapeGvariantString(value)},
                         nullptr, errorText);
 }
 


### PR DESCRIPTION
### 问题

GNOME Wayland 下，托盘每次启动都会弹"创建全局快捷键失败"通知，全局快捷键始终注册不上。

### 根因

GNOME 后端（`GnomeGlobalShortcutBackend`）用 `gsettings set` 写入每条自定义快捷键的 `name` / `command` / `binding`，但值是**不加引号**直接传的。截图快捷键的命令由 `windows_tray_controller.cpp` 里的 `selfCommand = "\"%1\""` 拼成 `"/usr/bin/mark-shot" --capture`。`gsettings` 会把键值参数按 GVariant 语法解析：`"…"` 被当作一个完整的带引号字符串吃掉，尾部的 ` --capture` 变成多余内容，于是报错：

```
expected end of input:
  "/usr/bin/mark-shot" --capture
                       ^
```

每条写入都失败，`registerShortcuts()` 判定该后端注册失败；而 `xdg-desktop-portal-gnome` 又没有实现 `GlobalShortcuts` portal 接口，所以托盘最终弹出失败通知。

### 修复

把反斜杠与单引号转义后，用单引号把整个值包裹起来，这样任意值（包括空格、内嵌双引号）都能原样写入 gsettings：

```cpp
QString escapeGvariantString(const QString &value)
{
    QString escaped = value;
    escaped.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
    escaped.replace(QLatin1Char('\''), QStringLiteral("\\'"));
    return QStringLiteral("'%1'").arg(escaped);
}
```

### 验证

在真实 `gsettings set` 上复现并验证：

| 传给 gsettings 的值 | 结果 |
|---|---|
| `"/usr/bin/mark-shot" --capture`（原始值） | `expected end of input` |
| `'"/usr/bin/mark-shot" --capture'`（转义后） | 原样写入 |
| `C:\dir\'quotes`（转义后） | 原样写入 |

修复后，GNOME 后端能成功把 `mark-shot-capture` 写入 `custom-keybindings`，GNOME Wayland 下全局快捷键即可生效。