### PR TITLE
fix(wayland): smooth initial region selection

### DIFF
--- a/src/layer_shell_runtime.cpp
+++ b/src/layer_shell_runtime.cpp
@@ -6,6 +6,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QPluginLoader>
+#include <QProcessEnvironment>
 
 #include <memory>
 
@@ -23,6 +24,25 @@ QString pluginFileName()
 #else
     return QStringLiteral("libmark-shot-layer-shell.so");
 #endif
+}
+
+/// @brief Returns whether the active session is GNOME running on Wayland.
+/// GNOME does not advertise the layer-shell protocol to regular clients.
+bool isGnomeWaylandSession()
+{
+    const QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+    if (environment.value(QStringLiteral("XDG_SESSION_TYPE"))
+            .compare(QStringLiteral("wayland"), Qt::CaseInsensitive)
+        != 0) {
+        return false;
+    }
+
+    const QString desktop =
+        (environment.value(QStringLiteral("XDG_CURRENT_DESKTOP")) + QLatin1Char(':')
+         + environment.value(QStringLiteral("XDG_SESSION_DESKTOP")) + QLatin1Char(':')
+         + environment.value(QStringLiteral("DESKTOP_SESSION")))
+            .toLower();
+    return desktop.contains(QStringLiteral("gnome"));
 }
 
 /// @brief Adds a search directory to the list if it is not already present.
@@ -63,6 +83,16 @@ QStringList pluginSearchDirs()
 /// @return Pointer to the loaded PluginInterface, or nullptr on failure.
 PluginInterface *loadPlugin()
 {
+    // Do this before QPluginLoader touches LayerShellQt.  Checking only in the
+    // plugin implementation is too late on GNOME: Qt may already have assigned
+    // an xdg-shell integration to the native window and emit role-conflict
+    // warnings while LayerShellQt is loaded.
+    if (isGnomeWaylandSession()) {
+        markshot::debugLog("layershell",
+                           "skipping optional layer-shell plugin: GNOME Wayland does not support layer-shell");
+        return nullptr;
+    }
+
     /// @brief Struct maintaining the state of the loaded plugin.
     struct LoaderState {
         /// @brief Flag indicating whether a plugin loading attempt has been made.

--- a/src/shot_window.h
+++ b/src/shot_window.h
@@ -7,6 +7,7 @@
 #include <QKeySequence>
 #include <QPointer>
 #include <QPointF>
+#include <QRegion>
 #include <QRect>
 #include <QRectF>
 #include <QStringList>
@@ -163,6 +164,11 @@ protected:
     void closeEvent(QCloseEvent *event) override;
 
 private:
+    void scheduleInitialSelectionRepaint(const QRegion &region);
+    void flushInitialSelectionRepaint();
+    QRegion initialSelectionDirtyRegion(const QRectF &previousSelection,
+                                        bool previousSelectionUsable) const;
+
     // High-level interaction mode: first pick a capture region, then edit the
     // selected image area and its annotations.
     enum class Mode {
@@ -680,6 +686,11 @@ private:
     bool m_activeRecordingStopHovered = false;
     markshot::startup_hint::PanelAnchor m_startupHintAnchor = markshot::startup_hint::PanelAnchor::BottomLeft;
     bool m_dragging = false;
+    // Pointer input can arrive at the native refresh rate (200 Hz on some
+    // Wayland displays). Keep selection geometry current for precision, but
+    // coalesce expensive raster repaint requests to a bounded cadence.
+    QTimer *m_initialSelectionRepaintTimer = nullptr;
+    QRegion m_pendingInitialSelectionRepaint;
     bool m_annotationHistoryCaptured = false;
     bool m_annotationSelectionBoxActive = false;
     bool m_fullscreenAnnotation = false;

--- a/src/shot_window_canvas.cpp
+++ b/src/shot_window_canvas.cpp
@@ -284,9 +284,12 @@ void ShotWindow::drawStartupToolOverlay(QPainter &painter)
     }
 }
 
-void ShotWindow::paintEvent(QPaintEvent *)
+void ShotWindow::paintEvent(QPaintEvent *event)
 {
     QPainter painter(this);
+    if (event) {
+        painter.setClipRegion(event->region());
+    }
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.fillRect(rect(), QColor(0, 0, 0));
     const qreal imageScale = m_frozenFrame.isNull()

--- a/src/shot_window_input.cpp
+++ b/src/shot_window_input.cpp
@@ -4,6 +4,80 @@ namespace cfg = markshot::config;
 namespace shortcuts = markshot::shortcut;
 using namespace markshot::shot;
 
+void ShotWindow::scheduleInitialSelectionRepaint(const QRegion &region)
+{
+    if (region.isEmpty()) {
+        return;
+    }
+
+    m_pendingInitialSelectionRepaint |= region;
+    if (m_initialSelectionRepaintTimer && !m_initialSelectionRepaintTimer->isActive()) {
+        m_initialSelectionRepaintTimer->start();
+    }
+}
+
+void ShotWindow::flushInitialSelectionRepaint()
+{
+    if (m_initialSelectionRepaintTimer) {
+        m_initialSelectionRepaintTimer->stop();
+    }
+
+    const QRegion pending = std::exchange(m_pendingInitialSelectionRepaint, QRegion());
+    if (!pending.isEmpty()) {
+        update(pending);
+    }
+}
+
+QRegion ShotWindow::initialSelectionDirtyRegion(const QRectF &previousSelection,
+                                                 bool previousSelectionUsable) const
+{
+    const QRectF currentSelection = normalizedSelection();
+    const bool currentSelectionUsable = currentSelection.width() >= kMinSelectionSize
+        && currentSelection.height() >= kMinSelectionSize;
+
+    // Before a usable rectangle exists the entire overlay uses the lighter
+    // startup dim. Crossing that threshold changes the whole backdrop once.
+    if (!previousSelectionUsable || !currentSelectionUsable) {
+        return QRegion(rect());
+    }
+
+    const QRect previousRect = imageRectToWidget(previousSelection).toAlignedRect();
+    const QRect currentRect = imageRectToWidget(currentSelection).toAlignedRect();
+    QRegion dirty(previousRect);
+    dirty ^= QRegion(currentRect);
+
+    // The selection border and its dimension label are drawn outside the
+    // changing dim area. Add just that chrome instead of invalidating the
+    // complete selection rectangle.
+    auto chromeRegion = [](const QRect &selection) {
+        constexpr int kBorderPadding = 4;
+        constexpr int kLabelWidth = 160;
+        constexpr int kLabelHeight = 40;
+
+        const QRect outer = selection.adjusted(-kBorderPadding,
+                                               -kBorderPadding,
+                                               kBorderPadding,
+                                               kBorderPadding);
+        const QRect inner = selection.adjusted(kBorderPadding,
+                                               kBorderPadding,
+                                               -kBorderPadding,
+                                               -kBorderPadding);
+        QRegion chrome(outer);
+        if (inner.isValid()) {
+            chrome -= inner;
+        }
+        chrome |= QRect(selection.left() + 4,
+                        selection.top() + 4,
+                        kLabelWidth,
+                        kLabelHeight);
+        return chrome;
+    };
+
+    dirty |= chromeRegion(previousRect);
+    dirty |= chromeRegion(currentRect);
+    return dirty.intersected(rect());
+}
+
 void ShotWindow::mouseMoveEvent(QMouseEvent *event)
 {
     if (m_imagePanning) {
@@ -64,9 +138,13 @@ void ShotWindow::mouseMoveEvent(QMouseEvent *event)
         }
     }
     if (m_mode == Mode::Selecting && m_dragging) {
+        const QRectF previousSelection = normalizedSelection();
+        const bool previousSelectionUsable = previousSelection.width() >= kMinSelectionSize
+            && previousSelection.height() >= kMinSelectionSize;
         m_selection = normalizedRect(m_selectionStart, imagePoint);
         revealSelectionInfo();
-        update();
+        scheduleInitialSelectionRepaint(
+            initialSelectionDirtyRegion(previousSelection, previousSelectionUsable));
         return;
     }
 
@@ -389,6 +467,9 @@ void ShotWindow::mouseReleaseEvent(QMouseEvent *event)
     }
 
     m_dragging = false;
+    if (m_mode == Mode::Selecting) {
+        flushInitialSelectionRepaint();
+    }
     if (m_toolbarDragging) {
         m_toolbarDragging = false;
         updateCursor();

--- a/src/shot_window_setup.cpp
+++ b/src/shot_window_setup.cpp
@@ -118,6 +118,19 @@ ShotWindow::ShotWindow(QImage frozenFrame,
     m_annotationStateTimer->setInterval(250);
     connect(m_annotationStateTimer, &QTimer::timeout, this, [this] { flushAnnotationStateNow(); });
 
+    // A full-screen selection overlay is expensive to rasterize.  Pointer
+    // events may arrive at 200 Hz while the display only needs a bounded UI
+    // cadence, so batch initial-selection damage into at most 120 repaints/s.
+    m_initialSelectionRepaintTimer = new QTimer(this);
+    m_initialSelectionRepaintTimer->setSingleShot(true);
+    m_initialSelectionRepaintTimer->setInterval(8);
+    connect(m_initialSelectionRepaintTimer, &QTimer::timeout, this, [this] {
+        const QRegion pending = std::exchange(m_pendingInitialSelectionRepaint, QRegion());
+        if (!pending.isEmpty()) {
+            update(pending);
+        }
+    });
+
     // 选中标注的滚轮改粗细需要进入撤销历史,但连续滚轮只应对应一次撤销
     m_annotationWidthWheelHistoryTimer = new QTimer(this);
     m_annotationWidthWheelHistoryTimer->setSingleShot(true);


### PR DESCRIPTION
# 高刷新率 GNOME Wayland 下的框选性能与 layer-shell 兼容性

## 问题

在 GNOME Wayland 的高刷新率显示器上拖动截图选区时明显卡顿。以 2560×1440、200Hz 显示器为例，鼠标移动事件频率很高，选区覆盖层无法稳定跟随指针。

同时，启动截图时终端会出现 LayerShellQt 的 shell integration 冲突与初始化失败警告。

## 根因

初始框选阶段，`ShotWindow::mouseMoveEvent()` 对每个鼠标移动事件都调用完整 `update()`。

`paintEvent()` 随后会重新绘制整个窗口：冻结截图、全屏暗罩、选区边框、尺寸标签以及其他画布元素。高刷新率环境中，这相当于以接近鼠标事件频率反复重绘整张 2560×1440 图像，造成主线程和栅格化压力过高。

LayerShellQt 警告是独立的兼容性问题：运行时会先加载可选 layer-shell 插件；GNOME Wayland 并不支持 layer-shell 协议，此时再由插件内部拒绝已经过晚，Qt 原生窗口可能已绑定 xdg-shell integration。

## 修复

- 保持选区坐标按每个鼠标事件实时更新，不降低框选精度。
- 将重绘请求合并到单次 8ms 定时器中，最多约 120 次/秒。
- 对已有效的选区，仅失效旧选区与新选区的差异区域，以及边框和尺寸标签所在区域。
- 在选区从“无效”变为“有效”时保留一次全屏重绘，确保暗罩透明度切换正确。
- `paintEvent()` 使用 `QPaintEvent` 的脏区裁剪，避免无关区域被重复绘制。
- 在加载 LayerShellQt 插件前检测 GNOME Wayland，并直接采用既有的 xdg-window 回退路径。

## 验证

- 已使用 `RelWithDebInfo` 完成全量构建。
- 已执行完整 CTest：61/61 通过。
- 在 GNOME Wayland、2560×1440、200Hz 显示器上手工快速拖动选区，确认不再出现明显卡顿。
- 调试日志确认 GNOME Wayland 不再加载 layer-shell 插件：

  ```text
  [layershell] skipping optional layer-shell plugin: GNOME Wayland does not support layer-shell
  ```
- 未实际测试 Windows、macOS 和其他 Linux 合成器；这些环境不匹配 GNOME Wayland 判断条件，预期保持原有路径。