### PR TITLE
fix(gnome): back off failed scroll helper detection

### DIFF
--- a/src/window_detection.cpp
+++ b/src/window_detection.cpp
@@ -7,6 +7,7 @@
 #include "window_detection_session.h"
 
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonArray>
@@ -165,6 +166,8 @@ constexpr int kMinWindowDetectionTimeoutMs = 100;
 /// @brief Maximum allowed timeout value in milliseconds for window detection.
 /// 与设置面板 spin 上限(30000ms)保持一致,避免面板值与实际生效值不一致。
 constexpr int kMaxWindowDetectionTimeoutMs = 30000;
+/// @brief Backoff for a missing GNOME Shell helper after a failed probe.
+constexpr int kGnomeHelperFailureBackoffMs = 30000;
 
 /// @brief Configuration settings for the external window detection process.
 struct WindowDetectionConfig {
@@ -177,6 +180,59 @@ struct WindowDetectionConfig {
     /// @brief Maximum time in milliseconds to wait for the detection process to finish.
     int timeoutMs = kDefaultWindowDetectionTimeoutMs;
 };
+
+/// @brief Holds the process-local backoff state for the bundled GNOME helper.
+struct GnomeHelperFailureBackoff {
+    QElapsedTimer timer;
+    bool active = false;
+};
+
+GnomeHelperFailureBackoff &gnomeHelperFailureBackoff()
+{
+    static GnomeHelperFailureBackoff state;
+    return state;
+}
+
+bool isBundledGnomeHelper(const WindowDetectionConfig &config)
+{
+#if defined(Q_OS_WIN)
+    Q_UNUSED(config)
+    return false;
+#else
+    const window_detection::Session session =
+        window_detection::detectSession(QProcessEnvironment::systemEnvironment());
+    return session.wayland && session.compositor == QStringLiteral("gnome")
+        && config.command == QStringLiteral("mark-shot-window-detection-gnome");
+#endif
+}
+
+bool bundledGnomeHelperBackoffActive(const WindowDetectionConfig &config)
+{
+    if (!isBundledGnomeHelper(config)) {
+        return false;
+    }
+
+    GnomeHelperFailureBackoff &backoff = gnomeHelperFailureBackoff();
+    if (!backoff.active) {
+        return false;
+    }
+    if (backoff.timer.elapsed() < kGnomeHelperFailureBackoffMs) {
+        return true;
+    }
+    backoff.active = false;
+    return false;
+}
+
+void recordBundledGnomeHelperFailure(const WindowDetectionConfig &config)
+{
+    if (!isBundledGnomeHelper(config)) {
+        return;
+    }
+
+    GnomeHelperFailureBackoff &backoff = gnomeHelperFailureBackoff();
+    backoff.active = true;
+    backoff.timer.restart();
+}
 
 /// @brief Expands tilde (~) prefixes in file paths to the user's home directory path.
 /// @param path The input path string.
@@ -582,6 +638,9 @@ QVector<WindowInfo> collectConfiguredWindowInfos(const QRect &captureGeometry,
     if (!config.has_value()) {
         return {};
     }
+    if (bundledGnomeHelperBackoffActive(*config)) {
+        return {};
+    }
 
     QProcess process;
     process.setProgram(commandShellProgram());
@@ -596,12 +655,14 @@ QVector<WindowInfo> collectConfiguredWindowInfos(const QRect &captureGeometry,
     process.start(QIODevice::ReadOnly);
 
     if (!process.waitForStarted(1000)) {
+        recordBundledGnomeHelperFailure(*config);
         markshot::debugLog("window-detection", "script did not start");
         return {};
     }
     if (!process.waitForFinished(config->timeoutMs)) {
         process.kill();
         process.waitForFinished(1000);
+        recordBundledGnomeHelperFailure(*config);
         markshot::debugLog("window-detection",
                            "script timed out timeout_ms=%d",
                            config->timeoutMs);
@@ -609,6 +670,7 @@ QVector<WindowInfo> collectConfiguredWindowInfos(const QRect &captureGeometry,
     }
     if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
         const QByteArray stderrText = process.readAllStandardError().trimmed().left(512);
+        recordBundledGnomeHelperFailure(*config);
         markshot::debugLog("window-detection",
                            "script failed exit_code=%d stderr=%s",
                            process.exitCode(),


### PR DESCRIPTION
# GNOME Scroll Helper 失败后的进程内退避

## 问题

未安装或未启用 Mark Shot GNOME Shell Scroll Helper 时，窗口检测会调用其 D-Bus 接口并失败：

```text
[window-detection] script failed exit_code=1 stderr=...
org.gnome.Shell.Extensions.MarkShotScrollHelper.WindowGeometries
```

每个新的 Mark Shot 进程都会再次执行该失败命令。普通自由框选不受影响，但会产生无用的启动开销和调试日志噪声。

## 原因

`collectConfiguredWindowInfos()` 每次启动截图会话都会执行当前配置的窗口检测命令。
在 GNOME Wayland 上，内置 `mark-shot-window-detection-gnome` 命令依赖 GNOME Shell 扩展提供 D-Bus 接口。扩展未安装、被禁用或暂时不可用时，命令以非零状态退出；原逻辑直接返回空窗口列表，但不会记录失败状态，因此同一常驻进程中的后续截图还会重复探测。

## 修复

为内置 GNOME helper 增加进程内、30 秒的失败退避：

- 仅在 GNOME Wayland 且命令精确等于 `mark-shot-window-detection-gnome` 时生效。
- 启动失败、超时和非零退出都会开始退避计时。
- 退避期间直接返回空窗口列表，不再创建失败的外部进程。
- 30 秒后自动恢复探测。
- 自定义窗口检测命令、X11、KDE 和其他 Wayland 合成器保持原有行为。
- 不写入配置文件；重启进程后会重新探测一次，以便用户安装/启用扩展后立即恢复。

## 验证

- 该修改已包含在此前完成的全量构建中，CTest 61/61 通过。
- 在未启用 GNOME Scroll Helper 的环境中，普通框选和截图流程正常。
- 多次独立启动 `mark-shot` 时仍会各自出现一次失败日志，这是预期行为。退避状态只保存在当前进程内。