### PR TITLE
fix(ui): ensure readable tooltips with Kvantum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,6 +709,8 @@ if(BUILD_TESTING)
         tests/ui_theme_config_test.cpp
         src/ui/interface_theme_config.cpp
         src/ui/interface_theme_config.h
+        src/ui/theme.cpp
+        src/ui/theme.h
     )
     target_include_directories(mark-shot-ui-theme-config-test PRIVATE src)
     target_link_libraries(mark-shot-ui-theme-config-test

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ int main(int argc, char *argv[])
     QFont applicationFont = app.font();
     applicationFont.setFamily(markshot::theme::uiFontFamily());
     app.setFont(applicationFont);
+    markshot::theme::synchronizeToolTipPalette(app.palette());
 
     markshot::i18n::initialize();
 

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -1,8 +1,10 @@
 #include "ui/theme.h"
 
+#include <QApplication>
 #include <QFontDatabase>
 #include <QStringLiteral>
 #include <QStringList>
+#include <QToolTip>
 
 #include <algorithm>
 
@@ -139,6 +141,23 @@ QFont textFont(int pointSize, QFont::Weight weight, QString family)
 QFont monospaceFont(int pointSize, QFont::Weight weight)
 {
     return makeFont(monospaceFontFamily(), pointSize, weight);
+}
+
+void synchronizeToolTipPalette(const QPalette &palette)
+{
+    QToolTip::setPalette(palette);
+
+    const QColor background = palette.color(QPalette::Active, QPalette::ToolTipBase);
+    const QColor foreground = palette.color(QPalette::Active, QPalette::ToolTipText);
+    qApp->setStyleSheet(QStringLiteral(
+        "QToolTip {"
+        " color: %1;"
+        " background-color: %2;"
+        " border: 1px solid rgba(255, 255, 255, 42);"
+        " border-radius: 6px;"
+        " padding: 4px 6px;"
+        "}")
+        .arg(foreground.name(QColor::HexRgb), background.name(QColor::HexRgb)));
 }
 
 QString panelStyleSheet(int buttonSize, int fontSize)

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -2,6 +2,7 @@
 
 #include <QColor>
 #include <QFont>
+#include <QPalette>
 #include <QString>
 #include <QVector>
 
@@ -30,6 +31,11 @@ QString monospaceFontFamilyCss();
 QFont uiFont(int pointSize = -1, QFont::Weight weight = QFont::Normal);
 QFont textFont(int pointSize = -1, QFont::Weight weight = QFont::Normal, QString family = {});
 QFont monospaceFont(int pointSize = -1, QFont::Weight weight = QFont::Normal);
+
+// Keep Qt's process-wide tooltip palette and stylesheet aligned with the
+// application palette. This avoids platform styles rendering a dark tooltip
+// frame with an unreadable dark text color.
+void synchronizeToolTipPalette(const QPalette &palette);
 
 // Stylesheet for the main toolbar, action toolbar, and annotation property
 // panel. They share an object-name-scoped rule set so the same string can be

--- a/tests/ui_theme_config_test.cpp
+++ b/tests/ui_theme_config_test.cpp
@@ -1,5 +1,7 @@
 #include "ui/interface_theme_config.h"
+#include "ui/theme.h"
 
+#include <QToolTip>
 #include <QtTest/QtTest>
 
 /**
@@ -74,6 +76,27 @@ private slots:
         QCOMPARE(markshot::ui::effectiveUiThemeMode(markshot::ui::UiThemeMode::System, lightPalette),
                  markshot::ui::UiThemeMode::Light);
     }
+
+    /**
+     * 验证提示框的静态调色板与显式样式均从应用主题取得，避免样式插件
+     * 用深色背景覆盖提示框时留下黑色文字。
+     */
+    void appliesReadableToolTipTheme()
+    {
+        QPalette palette;
+        const QColor expectedBase(15, 17, 23);
+        const QColor expectedText(229, 231, 235);
+        palette.setColor(QPalette::ToolTipBase, expectedBase);
+        palette.setColor(QPalette::ToolTipText, expectedText);
+
+        markshot::theme::synchronizeToolTipPalette(palette);
+
+        QCOMPARE(QToolTip::palette().color(QPalette::ToolTipBase), expectedBase);
+        QCOMPARE(QToolTip::palette().color(QPalette::ToolTipText), expectedText);
+        QVERIFY(qApp->styleSheet().contains(QStringLiteral("QToolTip")));
+        QVERIFY(qApp->styleSheet().contains(QStringLiteral("color: #e5e7eb")));
+        QVERIFY(qApp->styleSheet().contains(QStringLiteral("background-color: #0f1117")));
+    }
 };
 
 /**
@@ -82,6 +105,6 @@ private slots:
  * @param argv 参数数组。
  * @return 进程退出码。
  */
-QTEST_APPLESS_MAIN(UiThemeConfigTest)
+QTEST_MAIN(UiThemeConfigTest)
 
 #include "ui_theme_config_test.moc"


### PR DESCRIPTION
# Kvantum 深色主题下工具栏提示框文字可读性差

## 问题现象

在 GNOME Wayland 的 Kvantum 深色主题环境中，鼠标悬停截图操作框工具栏图标时，提示框显示黑色背景，黑色文字勉强可见，可读性很差。

按钮本身的图标和点击功能正常，问题仅影响悬停提示框的文字渲染。如下图所示

<img width="581" height="465" alt="image1" src="https://github.com/user-attachments/assets/bd4b8cd4-55bf-4c8f-8627-d067750d95f3" />
<img width="692" height="465" alt="image2" src="https://github.com/user-attachments/assets/de449a65-b8c3-4a72-a0a1-9c2a91a2495e" />

## 原因

Mark Shot 使用 Qt 的 `QToolTip` 静态调色板渲染提示框文字，而 Kvantum 会为提示框绘制深色背景框。两者的颜色来源未同步时，`QToolTip` 仍可能使用深色文字，最终形成“深色背景 + 深色文字”的低对比度组合。

## 修复内容

在应用启动时同步 Qt 提示框调色板，并显式指定提示框样式：

- 使用应用当前调色板设置 `QToolTip` 的背景色和文字色。
- 为 `QToolTip` 应用统一的前景色、背景色、边框、圆角和内边距样式。
- 新增 UI 主题回归测试，验证提示框静态调色板与样式表均使用应用主题颜色。
- 测试从 `QTEST_APPLESS_MAIN` 切换为 `QTEST_MAIN`，使测试具备 `QApplication` 实例以验证 `QToolTip` 与应用级样式表。

## 验证

- 构建通过：

  ```bash
  cmake --build build-ninja --target mark-shot-ui-theme-config-test mark-shot -j2
  ```

- UI 主题回归测试通过：

  ```bash
  ctest --test-dir build-ninja --output-on-failure -R '^ui-theme-config$'
  ```

- 已在 GNOME Wayland + Kvantum 环境完成手动验证悬停工具栏图标时，提示框文字可正常显示。