### PR TITLE
fix(kde): filter fully occluded windows

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -114,6 +114,10 @@ add_test(NAME niri-window-detection
     COMMAND ${CMAKE_COMMAND} -E env PYTHONDONTWRITEBYTECODE=1
         ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/niri_window_detection_test.py
 )
+add_test(NAME kde-window-detection
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONDONTWRITEBYTECODE=1
+        ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/kde_window_detection_test.py
+)
 
 qt_add_executable(mark-shot-pinned-window-config-test
     tests/pinned_window_config_test.cpp

--- a/scripts/mark-shot-window-detection-kde
+++ b/scripts/mark-shot-window-detection-kde
@@ -60,6 +60,44 @@ def intersects(left, right):
     return ax < bx + bw and bx < ax + aw and ay < by + bh and by < ay + ah
 
 
+def rectangle_difference(rect, occluder):
+    """返回 rect 被 occluder 覆盖后剩余的矩形区域。"""
+    x, y, width, height = rect
+    ox, oy, owidth, oheight = occluder
+    ix = max(x, ox)
+    iy = max(y, oy)
+    ix2 = min(x + width, ox + owidth)
+    iy2 = min(y + height, oy + oheight)
+
+    if ix >= ix2 or iy >= iy2:
+        return [rect]
+
+    pieces = []
+    if ix > x:
+        pieces.append((x, y, ix - x, height))
+    if ix2 < x + width:
+        pieces.append((ix2, y, x + width - ix2, height))
+    if iy > y:
+        pieces.append((ix, y, ix2 - ix, iy - y))
+    if iy2 < y + height:
+        pieces.append((ix, iy2, ix2 - ix, y + height - iy2))
+    return pieces
+
+
+def is_fully_occluded(rect, occluders):
+    """判断矩形是否被更高层窗口完全覆盖。"""
+    remaining = [rect]
+    for occluder in occluders:
+        remaining = [
+            piece
+            for candidate in remaining
+            for piece in rectangle_difference(candidate, occluder)
+        ]
+        if not remaining:
+            return True
+    return False
+
+
 def rect_adjustment():
     """读取 KDE 窗口矩形偏移配置。
     参数:
@@ -256,7 +294,7 @@ def script_source(token):
         return false;
     }}
 
-    function appendWindow(result, seen, window, zOrder) {{
+    function appendWindow(result, window, zOrder) {{
         if (!window || shouldSkip(window)) {{
             return;
         }}
@@ -264,11 +302,6 @@ def script_source(token):
         if (!rect) {{
             return;
         }}
-        const key = [rect.x, rect.y, rect.width, rect.height].join(",");
-        if (seen[key]) {{
-            return;
-        }}
-        seen[key] = true;
         const item = {{
             x: rect.x,
             y: rect.y,
@@ -306,10 +339,9 @@ def script_source(token):
     }}
 
     const result = [];
-    const seen = {{}};
     const windows = workspace.stackingOrder || [];
     for (let i = 0; i < windows.length; i += 1) {{
-        appendWindow(result, seen, windows[i], i);
+        appendWindow(result, windows[i], i);
     }}
     print("{MARKER} " + token + " " + JSON.stringify({{compositor: "kde", windows: result}}));
 }})();
@@ -555,6 +587,7 @@ def normalize_window(window):
         "fullScreen",
         "waylandClient",
         "x11Client",
+        "zOrder",
     ):
         if key in window:
             result[key] = window[key]
@@ -572,25 +605,36 @@ def selected_windows(payload):
     if not isinstance(windows, list):
         return []
 
+    candidates = []
+    for window in windows:
+        item = normalize_window(window)
+        if item is not None:
+            candidates.append(item)
+
+    visible = []
+    seen = set()
+    occluders = []
+    for item in reversed(candidates):
+        rect = (item["x"], item["y"], item["width"], item["height"])
+        if rect in seen:
+            continue
+        seen.add(rect)
+        if is_fully_occluded(rect, occluders):
+            continue
+        visible.append(item)
+        occluders.append(rect)
+    visible.reverse()
+
     capture = capture_rect()
     target_output = os.environ.get("MARK_SHOT_CAPTURE_OUTPUT", "").strip()
     all_outputs = os.environ.get("MARK_SHOT_CAPTURE_ALL_OUTPUTS") == "1"
     result = []
-    seen = set()
-
-    for window in windows:
-        item = normalize_window(window)
-        if item is None:
-            continue
+    for item in visible:
         if target_output and not all_outputs and item.get("output") not in ("", target_output):
             continue
         rect = (item["x"], item["y"], item["width"], item["height"])
         if capture is not None and not intersects(rect, capture):
             continue
-        key = tuple(rect)
-        if key in seen:
-            continue
-        seen.add(key)
         result.append(item)
     return result
 

--- a/src/capture_session_launcher.cpp
+++ b/src/capture_session_launcher.cpp
@@ -169,9 +169,6 @@ ShotWindow *showCaptureWindow(QScreen *screen,
         : (screen ? screen->geometry() : QRect());
     const QString outputName = (!allOutputs && screen) ? screen->name() : QString();
     const bool detectWindows = markshot::windowDetectionEnabled();
-    const QVector<markshot::WindowInfo> windowInfos = detectWindows
-        ? markshot::collectConfiguredWindowInfos(captureGeometry, outputName, allOutputs)
-        : QVector<markshot::WindowInfo>();
     CaptureRequest request;
     request.preferredOutputName = outputName;
     request.sourceGeometry = captureGeometry;
@@ -190,6 +187,12 @@ ShotWindow *showCaptureWindow(QScreen *screen,
         ? capture.sourceGeometry
         : captureGeometry;
     const QString capturedOutputName = capture.outputName.isEmpty() ? outputName : capture.outputName;
+    // Sample stacking after the pixels are captured. Portal capture can block
+    // while focus/stacking changes, so pre-capture geometry can describe a
+    // different desktop state than the frozen frame.
+    const QVector<markshot::WindowInfo> windowInfos = detectWindows
+        ? markshot::collectConfiguredWindowInfos(sourceGeometry, capturedOutputName, allOutputs)
+        : QVector<markshot::WindowInfo>();
     return showCapturedWindow(screen,
                               std::move(capture.image),
                               capturedOutputName,
@@ -422,9 +425,6 @@ QVector<CapturedScreenFrame> captureScreensIndividually(const QList<QScreen *> &
 
         const QRect captureGeometry = screen->geometry();
         const QString outputName = screen->name();
-        const QVector<markshot::WindowInfo> windowInfos = detectWindows
-            ? markshot::collectConfiguredWindowInfos(captureGeometry, outputName, false)
-            : QVector<markshot::WindowInfo>();
 
         CaptureRequest request;
         request.preferredOutputName = outputName;
@@ -458,7 +458,9 @@ QVector<CapturedScreenFrame> captureScreensIndividually(const QList<QScreen *> &
         frame.sourceGeometry = capture.sourceGeometry.isValid() && !capture.sourceGeometry.isEmpty()
             ? capture.sourceGeometry
             : captureGeometry;
-        frame.windowInfos = windowInfos;
+        frame.windowInfos = detectWindows
+            ? markshot::collectConfiguredWindowInfos(frame.sourceGeometry, frame.outputName, false)
+            : QVector<markshot::WindowInfo>();
         frame.detectWindows = detectWindows;
         markshot::debugLog("capture-session",
                            "【截图会话】【缩放诊断】individual-result screen=%s output=%s "

--- a/tests/kde_window_detection_test.py
+++ b/tests/kde_window_detection_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import os
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "mark-shot-window-detection-kde"
+LOADER = SourceFileLoader("mark_shot_window_detection_kde", str(SCRIPT_PATH))
+SPEC = spec_from_loader(LOADER.name, LOADER)
+KDE = module_from_spec(SPEC)
+LOADER.exec_module(KDE)
+
+
+class KdeWindowDetectionTest(unittest.TestCase):
+    def test_fully_occluded_window_is_filtered(self):
+        payload = {
+            "windows": [
+                {"x": 0, "y": 0, "width": 100, "height": 100, "title": "bottom"},
+                {"x": 0, "y": 0, "width": 50, "height": 100, "title": "left"},
+                {"x": 50, "y": 0, "width": 50, "height": 100, "title": "right"},
+            ]
+        }
+
+        with patch.dict(os.environ, {}, clear=True):
+            windows = KDE.selected_windows(payload)
+
+        self.assertEqual([window["title"] for window in windows], ["left", "right"])
+
+    def test_partially_visible_window_is_retained(self):
+        payload = {
+            "windows": [
+                {"x": 0, "y": 0, "width": 100, "height": 100, "title": "bottom"},
+                {"x": 0, "y": 0, "width": 90, "height": 100, "title": "top"},
+            ]
+        }
+
+        with patch.dict(os.environ, {}, clear=True):
+            windows = KDE.selected_windows(payload)
+
+        self.assertEqual([window["title"] for window in windows], ["bottom", "top"])
+
+    def test_topmost_duplicate_geometry_wins_and_keeps_z_order(self):
+        payload = {
+            "windows": [
+                {"x": 0, "y": 0, "width": 100, "height": 100, "title": "bottom", "zOrder": 0},
+                {"x": 20, "y": 20, "width": 20, "height": 20, "title": "middle", "zOrder": 1},
+                {"x": 0, "y": 0, "width": 100, "height": 100, "title": "top", "zOrder": 2},
+            ]
+        }
+
+        with patch.dict(os.environ, {}, clear=True):
+            windows = KDE.selected_windows(payload)
+
+        self.assertEqual([(window["title"], window["zOrder"]) for window in windows], [("top", 2)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- filter fully occluded KDE windows before exposing hover-selection candidates
- preserve partially visible windows and KWin z-order metadata
- keep the topmost window when duplicate geometries occur

## Testing
- `python3 tests/kde_window_detection_test.py`
- `git diff --check`
- live KDE/KWin check: a fullscreen/covering Vivaldi window was the only returned candidate while covered windows were omitted

GNOME already applies equivalent rectangle-based occlusion filtering; this brings the KDE detector to the same behavior.