### PR TITLE
feat: 支持自定义 OpenAI 翻译请求参数

### DIFF
--- a/cmake/provider_tests.cmake
+++ b/cmake/provider_tests.cmake
@@ -115,15 +115,23 @@ if(TARGET mark-shot-translate-openai)
         plugins/translate-openai/openai_translate_plugin.h
         plugins/translate-openai/openai_translation_parser.cpp
         plugins/translate-openai/openai_translation_parser.h
+        src/providers/provider_task.cpp
+        src/providers/provider_task.h
+        src/providers/translate/translate_openai_task.cpp
+        src/providers/translate/translate_openai_task.h
+        src/providers/translate/translate_segments.cpp
+        src/ocr_result.cpp
     )
     target_include_directories(mark-shot-translate-openai-plugin-test PRIVATE
         plugins/translate-openai
         plugin-sdk
+        src
     )
     target_link_libraries(mark-shot-translate-openai-plugin-test
         PRIVATE
             mark-shot-translate-common
             Qt6::Core
+            Qt6::Gui
             Qt6::Network
             Qt6::Test
     )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,7 @@ Mark Shot reads application settings from `~/.config/mark-shot/config.json` on L
     "apiKey": "",
     "model": "gpt-4o-mini",
     "temperature": 0.2,
+    "extraBody": {},
     "timeoutMs": 60000,
     "timeoutSeconds": 60,
     "systemPrompt": "",
@@ -141,6 +142,10 @@ Mark Shot reads application settings from `~/.config/mark-shot/config.json` on L
 ```
 
 Translation runs through provider plugins. See the [translation provider guide](translation-providers.md) for the `translation.provider` selection order, the Tencent, Baidu, and Youdao credential fields, their environment variables, and the per-vendor language codes.
+
+`translation.extraBody` adds JSON fields to the top level of OpenAI-compatible request bodies, for both the plugin and the built-in implementation. Edit this field directly in `config.json`; there is no settings control. For an API that supports it, use `"extraBody": {"enable_thinking": false}` to request disabling thinking. Other APIs may require `"extraBody": {"reasoning_effort": "none"}` instead. These fields and values depend on the API provider and model; they are not universal and may be rejected or ignored.
+
+The default is `{}`. Omitting the field or using an empty object preserves existing requests. Nested JSON values are passed through unchanged, but `model`, `temperature`, and `messages` always come from the application and cannot be overridden here. Non-object values (including `null`) cause a configuration error before sending a request. Only the shared `translation.extraBody` field is read, not `translation.openai.extraBody`. This feature does not apply to other translation providers, the helper, or a custom `translation.command`. Unsupported API fields follow the existing request error handling; they are not automatically removed and retried. Remove `extraBody` to restore the original request body.
 
 | Configuration Key | Data Type | Default Value | Description |
 | :--- | :---: | :---: | :--- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,25 @@ Translation runs through provider plugins. See the [translation provider guide](
 
 The default is `{}`. Omitting the field or using an empty object preserves existing requests. Nested JSON values are passed through unchanged, but `model`, `temperature`, and `messages` always come from the application and cannot be overridden here. Non-object values (including `null`) cause a configuration error before sending a request. Only the shared `translation.extraBody` field is read, not `translation.openai.extraBody`. This feature does not apply to other translation providers, the helper, or a custom `translation.command`. Unsupported API fields follow the existing request error handling; they are not automatically removed and retried. Remove `extraBody` to restore the original request body.
 
+For APIs that use `thinking.type`, the following configuration disables thinking and sets the temperature to `0`. Merge these fields into your existing `translation` object, keeping the API URL, credentials, and model; do not replace the entire configuration file with this snippet:
+
+```json
+{
+  "translation": {
+    "temperature": 0,
+    "extraBody": {
+      "thinking": {
+        "type": "disabled"
+      }
+    }
+  }
+}
+```
+
+To enable thinking, change `"disabled"` to `"enabled"`; do not use the literal value `"enabled/disabled"`. Set the temperature at `translation.temperature`; a `temperature` field inside `extraBody` is overwritten by the application. Check the provider's documentation to confirm that the model supports temperature `0` and allows it alongside the thinking parameter.
+
+`extraBody` accepts multiple comma-separated fields, all merged into a single request body rather than sent as separate bodies. For example, only if the API supports both parameters together, use `"extraBody": {"thinking": {"type": "disabled"}, "max_tokens": 1024}`. The outgoing request contains top-level `thinking` and `max_tokens` fields, without an outer `extraBody` field.
+
 | Configuration Key | Data Type | Default Value | Description |
 | :--- | :---: | :---: | :--- |
 | `env` | Object | `{}` | Environment variables applied to the process before `QApplication` creation (e.g., `"QT_FONT_DPI": 96` to normalize high-DPI scaling). Alias: `environment`. |

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -129,6 +129,7 @@ Mark Shot 在 Linux 上从 `~/.config/mark-shot/config.json` 读取应用配置�
     "apiKey": "",
     "model": "gpt-4o-mini",
     "temperature": 0.2,
+    "extraBody": {},
     "timeoutMs": 60000,
     "timeoutSeconds": 60,
     "systemPrompt": "",
@@ -141,6 +142,10 @@ Mark Shot 在 Linux 上从 `~/.config/mark-shot/config.json` 读取应用配置�
 ```
 
 翻译能力由 provider 插件提供。`translation.provider` 的取值顺序、腾讯与百度与有道的凭据字段、对应环境变量以及各家语言代码，见[翻译服务提供方文档](translation-providers.zh-CN.md)。
+
+`translation.extraBody` 用于向 OpenAI-compatible 请求体顶层添加 JSON 字段，同时适用于插件和内置实现。直接编辑 `config.json` 中的该字段即可，没有对应的设置页面控件。例如，在支持该参数的 API 上，可填写 `"extraBody": {"enable_thinking": false}` 请求关闭思考；其他 API 可能要求 `"extraBody": {"reasoning_effort": "none"}`。具体字段和值取决于服务商和模型，并非通用协议，可能被拒绝或忽略。
+
+默认值为 `{}`，省略字段或使用空对象均保持原有请求不变。嵌套 JSON 值原样透传，但 `model`、`temperature` 和 `messages` 始终由程序写入，不能在此覆盖。非对象值（包括 `null`）会在发送请求前报配置错误。只读取公共字段 `translation.extraBody`，不读取 `translation.openai.extraBody`。此功能不适用于其他翻译服务、helper 或自定义 `translation.command`。API 不支持的字段沿用现有请求错误处理，不会自动删除参数重试；删除 `extraBody` 即可恢复原有请求体。
 
 | 配置项键名 | 数据类型 | 默认值 | 功能描述 |
 | :--- | :---: | :---: | :--- |

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -147,6 +147,25 @@ Mark Shot 在 Linux 上从 `~/.config/mark-shot/config.json` 读取应用配置�
 
 默认值为 `{}`，省略字段或使用空对象均保持原有请求不变。嵌套 JSON 值原样透传，但 `model`、`temperature` 和 `messages` 始终由程序写入，不能在此覆盖。非对象值（包括 `null`）会在发送请求前报配置错误。只读取公共字段 `translation.extraBody`，不读取 `translation.openai.extraBody`。此功能不适用于其他翻译服务、helper 或自定义 `translation.command`。API 不支持的字段沿用现有请求错误处理，不会自动删除参数重试；删除 `extraBody` 即可恢复原有请求体。
 
+对于使用 `thinking.type` 的 API，关闭思考并将温度设为 `0` 的配置如下。将这些字段合入现有 `translation` 对象，保留已有地址、密钥和模型，不要用此片段替换整个配置文件：
+
+```json
+{
+  "translation": {
+    "temperature": 0,
+    "extraBody": {
+      "thinking": {
+        "type": "disabled"
+      }
+    }
+  }
+}
+```
+
+开启思考时，将 `"disabled"` 改为 `"enabled"`，不要填写 `"enabled/disabled"`。温度应写在 `translation.temperature`；即使在 `extraBody` 中填写 `temperature`，也会被程序覆盖。模型是否支持温度 `0`、能否与思考参数同时使用，仍需以服务商文档为准。
+
+`extraBody` 支持多个字段，用逗号分隔即可；它们会合并成同一个请求体，不是发送多个 body。例如，仅在 API 同时支持这些参数时，可使用 `"extraBody": {"thinking": {"type": "disabled"}, "max_tokens": 1024}`。最终请求体包含顶层 `thinking` 和 `max_tokens`，不会包含外层的 `extraBody` 字段。
+
 | 配置项键名 | 数据类型 | 默认值 | 功能描述 |
 | :--- | :---: | :---: | :--- |
 | `env` | 对象 | `{}` | 在创建 `QApplication` 之前应用到进程的环境变量（例如设置 `"QT_FONT_DPI": 96` 来规避高 DPI 缩放带来的截图边界偏移）。别名：`environment`。 |

--- a/plugins/translate-openai/openai_translate_config.cpp
+++ b/plugins/translate-openai/openai_translate_config.cpp
@@ -40,6 +40,7 @@ OpenAiTranslateConfig readOpenAiTranslateConfig()
         markshot::translate_common::readTranslateConfigSource(QStringLiteral("openai"));
 
     OpenAiTranslateConfig result;
+    result.extraBody = source.translation.value(QStringLiteral("extraBody"));
 
     // 1. apiBase 兼容旧配置使用的 baseUrl 键名
     QString apiBase = markshot::translate_common::configString(source, QStringLiteral("apiBase"), {});
@@ -83,6 +84,12 @@ OpenAiTranslateConfig readOpenAiTranslateConfig()
 
 bool validateOpenAiTranslateConfig(const OpenAiTranslateConfig &config, QString *error)
 {
+    if (!config.extraBody.isUndefined() && !config.extraBody.isObject()) {
+        if (error) {
+            *error = QStringLiteral("translation.extraBody must be a JSON object");
+        }
+        return false;
+    }
     if (config.apiBase.trimmed().isEmpty()) {
         if (error) {
             *error = QStringLiteral("missing translation apiBase");

--- a/plugins/translate-openai/openai_translate_config.h
+++ b/plugins/translate-openai/openai_translate_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QJsonValue>
 #include <QString>
 
 namespace markshot::translate_openai {
@@ -10,6 +11,8 @@ struct OpenAiTranslateConfig {
     QString apiKey;
     QString model = QStringLiteral("gpt-4o-mini");
     QString systemPrompt;
+    // Preserve invalid types until configuration validation.
+    QJsonValue extraBody{QJsonValue::Undefined};
     double temperature = 0.2;
     int timeoutMs = 60000;
 };

--- a/plugins/translate-openai/openai_translate_plugin.cpp
+++ b/plugins/translate-openai/openai_translate_plugin.cpp
@@ -53,15 +53,15 @@ QByteArray requestPayload(const OpenAiTranslateConfig &config,
                     QStringLiteral("Do not add explanations.")}},
         {QStringLiteral("segments"), segmentArray}};
 
-    const QJsonObject payload{
-        {QStringLiteral("model"), config.model},
-        {QStringLiteral("temperature"), config.temperature},
-        {QStringLiteral("messages"),
-         QJsonArray{QJsonObject{{QStringLiteral("role"), QStringLiteral("system")},
-                                {QStringLiteral("content"), config.systemPrompt}},
-                    QJsonObject{{QStringLiteral("role"), QStringLiteral("user")},
-                                {QStringLiteral("content"),
-                                 QString::fromUtf8(QJsonDocument(userPrompt).toJson(QJsonDocument::Compact))}}}}};
+    QJsonObject payload = config.extraBody.toObject();
+    payload.insert(QStringLiteral("model"), config.model);
+    payload.insert(QStringLiteral("temperature"), config.temperature);
+    payload.insert(QStringLiteral("messages"),
+                   QJsonArray{QJsonObject{{QStringLiteral("role"), QStringLiteral("system")},
+                                          {QStringLiteral("content"), config.systemPrompt}},
+                              QJsonObject{{QStringLiteral("role"), QStringLiteral("user")},
+                                          {QStringLiteral("content"),
+                                           QString::fromUtf8(QJsonDocument(userPrompt).toJson(QJsonDocument::Compact))}}});
     return QJsonDocument(payload).toJson(QJsonDocument::Compact);
 }
 

--- a/src/app_config_defaults.cpp
+++ b/src/app_config_defaults.cpp
@@ -147,6 +147,7 @@ QJsonObject defaultAppConfigRoot(const QString &windowDetectionCommand)
     translation.insert(QStringLiteral("apiKey"), QString());
     translation.insert(QStringLiteral("model"), QStringLiteral("gpt-4o-mini"));
     translation.insert(QStringLiteral("temperature"), 0.2);
+    translation.insert(QStringLiteral("extraBody"), QJsonObject());
     translation.insert(QStringLiteral("timeoutMs"), 60000);
     translation.insert(QStringLiteral("timeoutSeconds"), 60);
     translation.insert(QStringLiteral("systemPrompt"), QString());

--- a/src/providers/translate/translate_openai_task.cpp
+++ b/src/providers/translate/translate_openai_task.cpp
@@ -132,6 +132,11 @@ void TranslateOpenAiTask::start(int timeoutMs)
 
     // 2. 解析 API 配置，配置项与环境变量兜底顺序与旧 helper 一致
     const QJsonObject config = translationConfig(m_configPath);
+    const QJsonValue extraBody = config.value(QStringLiteral("extraBody"));
+    if (!extraBody.isUndefined() && !extraBody.isObject()) {
+        failWith(QStringLiteral("translation.extraBody must be a JSON object"));
+        return;
+    }
     const QString apiBase = firstNonEmpty(
         config.value(QStringLiteral("apiBase")).toString(config.value(QStringLiteral("baseUrl")).toString()),
         {QStringLiteral("MARK_SHOT_LLM_API_BASE"),
@@ -172,18 +177,18 @@ void TranslateOpenAiTask::start(int timeoutMs)
                                    "with no markdown."),
                     QStringLiteral("Do not add explanations.")}},
         {QStringLiteral("segments"), segmentArray}};
-    const QJsonObject payload{
-        {QStringLiteral("model"), model},
-        {QStringLiteral("temperature"),
-         config.contains(QStringLiteral("temperature"))
-             ? config.value(QStringLiteral("temperature")).toDouble(0.2)
-             : 0.2},
-        {QStringLiteral("messages"),
-         QJsonArray{QJsonObject{{QStringLiteral("role"), QStringLiteral("system")},
-                                {QStringLiteral("content"), systemPrompt}},
-                    QJsonObject{{QStringLiteral("role"), QStringLiteral("user")},
-                                {QStringLiteral("content"),
-                                 QString::fromUtf8(QJsonDocument(userPrompt).toJson(QJsonDocument::Compact))}}}}};
+    QJsonObject payload = extraBody.toObject();
+    payload.insert(QStringLiteral("model"), model);
+    payload.insert(QStringLiteral("temperature"),
+                   config.contains(QStringLiteral("temperature"))
+                       ? config.value(QStringLiteral("temperature")).toDouble(0.2)
+                       : 0.2);
+    payload.insert(QStringLiteral("messages"),
+                   QJsonArray{QJsonObject{{QStringLiteral("role"), QStringLiteral("system")},
+                                          {QStringLiteral("content"), systemPrompt}},
+                              QJsonObject{{QStringLiteral("role"), QStringLiteral("user")},
+                                          {QStringLiteral("content"),
+                                           QString::fromUtf8(QJsonDocument(userPrompt).toJson(QJsonDocument::Compact))}}});
 
     QNetworkRequest request(QUrl(apiBase + QStringLiteral("/chat/completions")));
     request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));

--- a/tests/translate_openai_plugin_test.cpp
+++ b/tests/translate_openai_plugin_test.cpp
@@ -1,6 +1,7 @@
 #include "openai_translate_config.h"
 #include "openai_translate_plugin.h"
 #include "openai_translation_parser.h"
+#include "providers/translate/translate_openai_task.h"
 
 #include <QtTest/QtTest>
 
@@ -126,9 +127,11 @@ private:
 /**
  * 写入临时 Mark Shot 配置。
  * @param apiBase API 根地址。
+ * @param extraBody 额外请求体，Undefined 表示省略该字段。
  * @return 临时配置文件。
  */
-QTemporaryFile *writeTempConfig(const QString &apiBase)
+QTemporaryFile *writeTempConfig(const QString &apiBase,
+                               const QJsonValue &extraBody = QJsonValue(QJsonValue::Undefined))
 {
     auto *file = new QTemporaryFile();
     if (!file->open()) {
@@ -141,6 +144,7 @@ QTemporaryFile *writeTempConfig(const QString &apiBase)
     translation.insert(QStringLiteral("model"), QStringLiteral("test-model"));
     translation.insert(QStringLiteral("temperature"), 0.0);
     translation.insert(QStringLiteral("timeoutMs"), 5000);
+    translation.insert(QStringLiteral("extraBody"), extraBody);
     QJsonObject root;
     root.insert(QStringLiteral("translation"), translation);
     file->write(QJsonDocument(root).toJson(QJsonDocument::Compact));
@@ -154,6 +158,120 @@ class TranslateOpenAiPluginTest : public QObject {
     Q_OBJECT
 
 private slots:
+    void extraBodyRequests_data()
+    {
+        QTest::addColumn<QJsonValue>("extraBody");
+        QTest::newRow("missing") << QJsonValue(QJsonValue::Undefined);
+        QTest::newRow("empty") << QJsonValue(QJsonObject());
+        QTest::newRow("extensions") << QJsonValue(QJsonObject{
+            {QStringLiteral("enable_thinking"), false},
+            {QStringLiteral("reasoning_effort"), QStringLiteral("none")},
+            {QStringLiteral("nested"), QJsonObject{
+                {QStringLiteral("values"), QJsonArray{false, 2, QStringLiteral("text"), QJsonValue()}}}}});
+        QTest::newRow("protected-fields") << QJsonValue(QJsonObject{
+            {QStringLiteral("model"), QStringLiteral("wrong-model")},
+            {QStringLiteral("temperature"), 99},
+            {QStringLiteral("messages"), QJsonArray()},
+            {QStringLiteral("enable_thinking"), false}});
+        QTest::newRow("null") << QJsonValue(QJsonValue::Null);
+        QTest::newRow("array") << QJsonValue(QJsonArray());
+        QTest::newRow("string") << QJsonValue(QStringLiteral("{}"));
+        QTest::newRow("number") << QJsonValue(1);
+        QTest::newRow("boolean") << QJsonValue(false);
+    }
+
+    void extraBodyRequests()
+    {
+        QFETCH(QJsonValue, extraBody);
+        const bool valid = extraBody.isUndefined() || extraBody.isObject();
+        const QString expectedError = QStringLiteral("translation.extraBody must be a JSON object");
+        const QJsonObject message{
+            {QStringLiteral("content"), QStringLiteral("{\"translations\":[{\"id\":7,\"text\":\"translated\"}]}")}};
+        const QJsonObject choice{{QStringLiteral("message"), message}};
+        const QByteArray response = QJsonDocument(
+            QJsonObject{{QStringLiteral("choices"), QJsonArray{choice}}}).toJson();
+        QJsonObject pluginPayload;
+        for (const bool builtin : {false, true}) {
+            MockChatServer server(response);
+            QVERIFY(server.start());
+            QSignalSpy connections(&server, &QTcpServer::newConnection);
+            std::unique_ptr<QTemporaryFile> config(writeTempConfig(server.baseUrl(), extraBody));
+            QVERIFY(config != nullptr);
+            EnvGuard configGuard(QByteArrayLiteral("MARK_SHOT_CONFIG"), config->fileName().toUtf8());
+
+            if (builtin) {
+                markshot::providers::TranslateOpenAiTask task(
+                    QByteArrayLiteral("{\"tokens\":[{\"text\":\"hello\",\"line\":7,\"box\":[0,0,50,20]}]}"),
+                    QStringLiteral("Simplified Chinese"), config->fileName());
+                task.start(5000);
+                const auto result = task.waitForResult();
+                QCOMPARE(result.ok, valid);
+                if (valid) {
+                    const QJsonArray tokens = QJsonDocument::fromJson(result.output).object()
+                                                  .value(QStringLiteral("tokens")).toArray();
+                    QCOMPARE(tokens.size(), 1);
+                    QCOMPARE(tokens.first().toObject().value(QStringLiteral("text")).toString(),
+                             QStringLiteral("translated"));
+                } else {
+                    QCOMPARE(result.error, markshot::providers::TaskError::Failed);
+                    QCOMPARE(QString::fromUtf8(result.errorOutput), expectedError);
+                }
+            } else {
+                OpenAiTranslatePlugin plugin;
+                QString error;
+                QCOMPARE(plugin.isAvailable(&error), valid);
+                if (!valid) {
+                    QCOMPARE(error, expectedError);
+                }
+                QVector<markshot::plugin::TranslateSegment> translations;
+                QCOMPARE(plugin.translate({{7, QStringLiteral("hello")}},
+                                          QStringLiteral("Simplified Chinese"), &translations, &error), valid);
+                if (valid) {
+                    QCOMPARE(translations.size(), 1);
+                    QCOMPARE(translations.first().id, 7);
+                    QCOMPARE(translations.first().text, QStringLiteral("translated"));
+                } else {
+                    QCOMPARE(error, expectedError);
+                    QVERIFY(translations.isEmpty());
+                }
+            }
+            if (!valid) {
+                QCoreApplication::processEvents();
+                QCOMPARE(connections.count(), 0);
+                QVERIFY(server.requestBody().isEmpty());
+                continue;
+            }
+
+            const QJsonObject payload = QJsonDocument::fromJson(server.requestBody()).object();
+            QCOMPARE(payload.value(QStringLiteral("model")).toString(), QStringLiteral("test-model"));
+            QCOMPARE(payload.value(QStringLiteral("temperature")), QJsonValue(0.0));
+            const QJsonArray messages = payload.value(QStringLiteral("messages")).toArray();
+            QCOMPARE(messages.size(), 2);
+            QCOMPARE(messages.first().toObject(), (QJsonObject{
+                {QStringLiteral("role"), QStringLiteral("system")},
+                {QStringLiteral("content"), defaultSystemPrompt()}}));
+            QCOMPARE(messages.last().toObject().value(QStringLiteral("role")).toString(), QStringLiteral("user"));
+            const QJsonObject prompt = QJsonDocument::fromJson(
+                messages.last().toObject().value(QStringLiteral("content")).toString().toUtf8()).object();
+            QCOMPARE(prompt.value(QStringLiteral("target_language")).toString(), QStringLiteral("Simplified Chinese"));
+            QCOMPARE(prompt.value(QStringLiteral("segments")).toArray(),
+                     (QJsonArray{QJsonObject{{QStringLiteral("id"), 7}, {QStringLiteral("text"), QStringLiteral("hello")}}}));
+            QCOMPARE(prompt.value(QStringLiteral("instructions")).toArray().size(), 3);
+            QJsonObject extensions = payload;
+            QJsonObject expectedExtensions = extraBody.toObject();
+            for (const QString &key : {QStringLiteral("model"), QStringLiteral("temperature"), QStringLiteral("messages")}) {
+                extensions.remove(key);
+                expectedExtensions.remove(key);
+            }
+            QCOMPARE(extensions, expectedExtensions);
+            if (builtin) {
+                QCOMPARE(payload, pluginPayload);
+            } else {
+                pluginPayload = payload;
+            }
+        }
+    }
+
     /**
      * 验证 Markdown 包裹的翻译 JSON 可被解析。
      * @return 无返回值。


### PR DESCRIPTION
[![AI-DECLARATION: copilot](https://img.shields.io/badge/䷼%20AI--DECLARATION-copilot-fee2e2?labelColor=fee2e2)](https://ai-declaration.md)

## 变更摘要

为 OpenAI-compatible 翻译新增 `translation.extraBody` 配置，允许向请求体添加服务商支持的参数，例如关闭模型思考。插件和内置实现使用相同的校验与合并规则。

Closes #97

## 背景与原因

原有翻译请求仅发送 `model`、`temperature` 和 `messages`，无法传入服务商自定义的思考参数。不同 API 的字段不统一，因此提供通用 JSON 对象，不增加特定服务商的开关，也不需要额外部署网关。

## 使用与行为

将以下字段合入现有配置，保留原有 API 地址、密钥和模型。示例仅适用于支持 `thinking.type` 的服务商与模型：

```json
{
  "translation": {
    "temperature": 0,
    "extraBody": {
      "thinking": {
        "type": "disabled"
      }
    }
  }
}
```

| 配置情况 | 行为 |
| --- | --- |
| 省略 `extraBody` 或填写 `{}` | 保持原有请求不变 |
| 多个扩展字段或嵌套 JSON | 合入同一个请求体顶层，嵌套值原样保留，不发送外层 `extraBody` |
| 扩展字段与 `model`、`temperature`、`messages` 冲突 | 程序控制字段优先；温度应配置在 `translation.temperature` |
| `extraBody` 为数组、字符串、数字、布尔值或 `null` | 报配置错误，不发送请求 |

## 影响范围

- 修改 OpenAI 翻译插件和内置任务，复用现有请求与错误处理流程。
- 默认配置增加空对象，中英文文档补充思考开关、温度和多字段示例；不新增设置页面或依赖。
- 只读取 `translation.extraBody`，不新增 `translation.openai.extraBody` 入口。
- 不改变其他翻译服务、helper 或自定义 `translation.command` 的行为；这些路径不支持该字段。
- 不涉及数据迁移；删除 `extraBody` 即可恢复原有请求体。

## 风险与限制

- 参数名称、取值及组合限制取决于服务商和模型；透传成功不保证思考已关闭。服务商可能拒绝或忽略参数，不自动删参数重试。
- 本地已验证请求内容及响应解析，尚未验证真实服务商、完整应用构建和桌面端操作。
