### PR TITLE
Install build dependencies in the PPA publication workflow

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -59,9 +59,16 @@ jobs:
             debhelper \
             devscripts \
             dput \
+            equivs \
             gnupg \
             lintian \
             python3
+
+      - name: Install declared build dependencies
+        run: |
+          mk-build-deps --install --remove \
+            --tool 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y' \
+            debian/control
 
       - name: Verify the canonical stable release
         id: release


### PR DESCRIPTION
## Summary

Install the package's declared build dependencies before creating a signed source upload in `ppa-publish.yml`.

## Why

The first real workflow dispatch for the adopted publication workflow failed at `dpkg-buildpackage -S` because it checks `Build-Depends` by default, while the job installed only source-package tooling:

https://github.com/arpagon/mark-shot/actions/runs/34243473356

`mk-build-deps` matches the clean package workflow and keeps this list sourced from `debian/control` rather than duplicating it in the workflow.

## Validation

- workflow YAML parses successfully
- the same `mk-build-deps` invocation is already exercised by the passing Resolute package workflow
- this branch will be used for a new protected publication dispatch of official stable tag `v0.1.51`
